### PR TITLE
Added a basic health check endpoint for use in CF

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,14 @@
+class HealthController < ApplicationController
+
+    # Returns application status and the current server timestamp
+    #
+    # @return [JSON] a JSON object containing the application status
+    #                and the current server timestamp
+    def get_status
+        render :json => {
+            'status' => 'OK',
+            'server_timestamp' => Time.new.strftime("%Y-%m-%d %H:%M:%S")
+        },
+        :status => 200
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  get 'health' => 'health#get_status'
+
   devise_for :users
   resources :projects, except: [:destroy]
   get 'dashboard/show'

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,6 +4,8 @@ applications:
   memory: 256M
   instances: 2
   buildpack: ruby_buildpack
-  services: 
+  health-check-type: http
+  health-check-http-endpoint: /health
+  services:
   - funding-frontend-staging
   - log-drain

--- a/test/controllers/health_controller_test.rb
+++ b/test/controllers/health_controller_test.rb
@@ -1,0 +1,8 @@
+class HealthControllerTest < ActionDispatch::IntegrationTest
+    test "should successfully call get_status" do
+      get '/health'
+      assert_response :success
+      assert_equal JSON.parse(response.body)["status"], "OK"
+    end
+  
+  end


### PR DESCRIPTION
Cloud Foundry can make use of a health check HTTP endpoint
(https://docs.cloudfoundry.org/devguide/deploy-apps/healthchecks.html#health_check_uri),
 and requires this to be added to an application. Rather than
 using the index route of the application, it makes more sense
 to add a specific route for serving this purpose. We can expand
 upon this later to add a health check that will also check
 application dependencies such as databases or other components.