### PR TITLE
Added migration containing org_type column

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,14 +1,14 @@
 class Organisation < ApplicationRecord
     has_many :users
-    enum type: {
-        registered_charity: 'registered_charity',
-        local_authority: 'local_authority',
-        registered_company: 'registered_company',
-        community_interest_company: 'community_interest_company',
-        faith_based_organisation: 'faith_based_organisation',
-        church_organisation: 'church_organisation',
-        community_group: 'community_group',
-        voluntary_group: 'voluntary_group',
-        individual_private_owner_of_heritage: 'individual_private_owner_of_heritage',
-        other: 'other'}
+    enum org_type: {
+        registered_charity: 0,
+        local_authority: 1,
+        registered_company: 2,
+        community_interest_company: 3,
+        faith_based_organisation: 4,
+        church_organisation: 5,
+        community_group: 6,
+        voluntary_group: 7,
+        individual_private_owner_of_heritage: 8,
+        other: 9}
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,3 +1,14 @@
-class Organisation < ApplicationRecord    
+class Organisation < ApplicationRecord
     has_many :users
+    enum type: {
+        registered_charity: 'registered_charity',
+        local_authority: 'local_authority',
+        registered_company: 'registered_company',
+        community_interest_company: 'community_interest_company',
+        faith_based_organisation: 'faith_based_organisation',
+        church_organisation: 'church_organisation',
+        community_group: 'community_group',
+        voluntary_group: 'voluntary_group',
+        individual_private_owner_of_heritage: 'individual_private_owner_of_heritage',
+        other: 'other'}
 end

--- a/db/migrate/20191211142201_add_type_to_organisations.rb
+++ b/db/migrate/20191211142201_add_type_to_organisations.rb
@@ -1,0 +1,18 @@
+class AddTypeToOrganisations < ActiveRecord::Migration[6.0]
+  def up
+    execute <<-DDL
+      CREATE TYPE organisations_type AS ENUM (
+        'registered_charity', 'local_authority', 'registered_company',
+        'community_interest_company', 'faith_based_organisation', 'church_organisation',
+        'community_group', 'voluntary_group', 'individual_private_owner_of_heritage',
+        'other'
+      );
+    DDL
+    add_column :organisations, :org_type, :organisations_type
+  end
+
+  def down
+    remove_column :organisations, :org_type
+    execute "DROP type organisations_type";
+  end
+end

--- a/db/migrate/20191211142201_add_type_to_organisations.rb
+++ b/db/migrate/20191211142201_add_type_to_organisations.rb
@@ -1,18 +1,5 @@
 class AddTypeToOrganisations < ActiveRecord::Migration[6.0]
-  def up
-    execute <<-DDL
-      CREATE TYPE organisations_type AS ENUM (
-        'registered_charity', 'local_authority', 'registered_company',
-        'community_interest_company', 'faith_based_organisation', 'church_organisation',
-        'community_group', 'voluntary_group', 'individual_private_owner_of_heritage',
-        'other'
-      );
-    DDL
-    add_column :organisations, :org_type, :organisations_type
-  end
-
-  def down
-    remove_column :organisations, :org_type
-    execute "DROP type organisations_type";
+  def change
+    add_column :organisations, :org_type, :integer
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_04_110301) do
+ActiveRecord::Schema.define(version: 2019_12_11_145241) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 2019_12_04_110301) do
     t.string "name"
     t.string "line2"
     t.string "line3"
+    t.integer "org_type"
   end
 
   create_table "projects", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
Each organisation has a type associated with it. I've added this
as a new type within the database migration when applying it to
the new column org_type - this will stop data that doesn't match
any of the values of the enumerator from being added within this
field. As well as adding this database migration, I've also added
the relevant field to the model to enable this.