### PR TITLE
Make users confirm email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :confirmable
     belongs_to :organisation, optional: true
     has_many :projects
    def self.find_or_create_from_auth_hash(auth_hash)

--- a/db/migrate/20191216113731_add_confirmable_to_devise.rb
+++ b/db/migrate/20191216113731_add_confirmable_to_devise.rb
@@ -1,0 +1,20 @@
+class AddConfirmableToDevise < ActiveRecord::Migration[6.0]
+  # Note: You can't use change, as User.update_all will fail in the down migration
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    # add_column :users, :unconfirmed_email, :string # Only if using reconfirmable
+    add_index :users, :confirmation_token, unique: true
+    # User.reset_column_information # Need for some types of updates, but not for update_all.
+    # To avoid a short time window between running the migration and updating all existing
+    # users as confirmed, do the following
+    User.update_all confirmed_at: DateTime.now
+    # All existing user accounts should be able to log in after this.
+  end
+
+  def down
+    remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at
+    # remove_columns :users, :unconfirmed_email # Only if using reconfirmable
+  end
+end

--- a/db/migrate/20191216113731_add_confirmable_to_devise.rb
+++ b/db/migrate/20191216113731_add_confirmable_to_devise.rb
@@ -4,7 +4,7 @@ class AddConfirmableToDevise < ActiveRecord::Migration[6.0]
     add_column :users, :confirmation_token, :string
     add_column :users, :confirmed_at, :datetime
     add_column :users, :confirmation_sent_at, :datetime
-    # add_column :users, :unconfirmed_email, :string # Only if using reconfirmable
+    add_column :users, :unconfirmed_email, :string # Only if using reconfirmable
     add_index :users, :confirmation_token, unique: true
     # User.reset_column_information # Need for some types of updates, but not for update_all.
     # To avoid a short time window between running the migration and updating all existing
@@ -15,6 +15,6 @@ class AddConfirmableToDevise < ActiveRecord::Migration[6.0]
 
   def down
     remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at
-    # remove_columns :users, :unconfirmed_email # Only if using reconfirmable
+    remove_columns :users, :unconfirmed_email # Only if using reconfirmable
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 2019_12_16_113731) do
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_12_120428) do
+ActiveRecord::Schema.define(version: 2019_12_16_113731) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -81,6 +81,10 @@ ActiveRecord::Schema.define(version: 2019_12_12_120428) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class DashboardControllerTest < ActionDispatch::IntegrationTest
   setup do
     get '/users/sign_in'
+    users(:one).confirm
     sign_in users(:one)
     post user_session_url
   end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -2,8 +2,10 @@ require 'test_helper'
 
 class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
-  setup do 
+
+  setup do
     get '/users/sign_in'
+    users(:one).confirm
     sign_in users(:one)
     post user_session_url
     @project = projects(:one)


### PR DESCRIPTION
https://trello.com/c/KkmAxQK2/871-implement-a-confirm-email-step-in-the-account-registration-flow
Note: locally you should see the confirm URL in the console you can use to test this.
Also, this uses the default flow provided by Devise which is quite clunky and seems to make you re-login after confirming. We should review this flow with @paulmsmith to see if it can be improved.