### PR TITLE
use safe navigation operator for humanize

### DIFF
--- a/app/views/organisation/organisation_summary/show.html.erb
+++ b/app/views/organisation/organisation_summary/show.html.erb
@@ -11,7 +11,7 @@
       </dt>
 
       <dd class="govuk-summary-list__value">
-        <%= @organisation.org_type.humanize %>
+        <%= @organisation.org_type&.humanize %>
       </dd>
 
       <dd class="govuk-summary-list__actions">
@@ -90,7 +90,7 @@
         <ul class="govuk-list">
           <% @organisation.mission.each do |mission| %>
             <li>
-              <%= mission.humanize %>
+              <%= mission&.humanize %>
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
I was getting an exception on staging because my organisation did not have one of the fields populated
```
ActionView::Template::Error (undefined method `humanize' for nil:NilClass): 
```
We can the safe navigation operator to not throw an exception in this case. 