### PR TITLE
add seed user

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,5 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+User.create(email: 'test@example.com', encrypted_password: User.new.send(:password_digest, '123456')).confirm


### PR DESCRIPTION
Adds an example user when `db:setup` or `db:seed` is run. This should ease the burden of having to register for local development.