### PR TITLE
bugfix: enable i18n fallbacks

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ module FundingFrontendRuby
     config.load_defaults 6.0
     config.assets.paths << Rails.root.join('node_modules')
     config.i18n.default_locale = :'en-GB'
+    config.i18n.fallbacks = true
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid
 


### PR DESCRIPTION
Switching to en-GB default locale broke Devise messages as they are set for `en`.
Setting this fallback option uses `en` where `en-GB` is not available.