### PR TITLE
Added functionality for project location mirroring organisation address

### DIFF
--- a/app/controllers/project/project_location_controller.rb
+++ b/app/controllers/project/project_location_controller.rb
@@ -1,4 +1,5 @@
 class Project::ProjectLocationController < ApplicationController
+  include ProjectContext
 
   def project_location
   end
@@ -6,15 +7,71 @@ class Project::ProjectLocationController < ApplicationController
   def project_other_location
   end
 
-  def save_project_location
-    same_location = params['same-location'].to_s == 'yes' ? true : false unless params['same-location'].nil?
+  def update
 
-    # todo really save same_location data
+    @project.validate_same_location = true
 
-    if (same_location == true)
-      redirect_to '/3-10k/project/description'
+    @project.update(project_params)
+
+    if @project.valid?
+
+      if @project.same_location == "yes"
+
+        logger.debug "Same location as organisation selected for project ID: #{@project.id}"
+
+        add_project_address_fields
+
+        @project.save
+
+        logger.debug "Finished updating location for project ID: #{@project.id}"
+
+        redirect_to three_to_ten_k_project_description_get_path(@project.id)
+
+      else
+
+        logger.debug "Different location to organisation selected for project ID: #{@project.id}"
+
+        # TODO: Replace this with a redirect to enter project location page
+        redirect_to three_to_ten_k_project_description_get_path(@project.id)
+
+      end
+
     else
-      redirect_to '/3-10k/project/other-location'
+
+      render :project_location
+
     end
+
   end
+
+  private
+
+  # Replicates address data from the organisation model linked to the current user
+  # into the project model address fields
+  def add_project_address_fields
+
+    logger.debug "Setting project address fields for project ID: #{@project.id}"
+
+    @organisation = Organisation.find(current_user.organisation.id)
+
+    @project.line1 = @organisation.line1
+    @project.line2 = @organisation.line2
+    @project.line3 = @organisation.line3
+    @project.townCity = @organisation.townCity
+    @project.county = @organisation.county
+    @project.postcode = @organisation.postcode
+
+    logger.debug "Finished setting project address fields for project ID: #{@project.id}"
+
+  end
+
+  def project_params
+
+    unless params[:project].present?
+      params.merge!({project: {same_location: ""}})
+    end
+
+    params.require(:project).permit(:same_location)
+  end
+
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -10,6 +10,7 @@ class Project < ApplicationRecord
 
     attr_accessor :validate_title
     attr_accessor :validate_start_and_end_dates
+    attr_accessor :validate_same_location
     attr_accessor :validate_description
 
     # These attributes are used to set individual error messages
@@ -20,6 +21,8 @@ class Project < ApplicationRecord
     attr_accessor :end_date_day
     attr_accessor :end_date_month
     attr_accessor :end_date_year
+
+    attr_accessor :same_location
 
     validates :project_title, presence: true, length: { maximum: 255 }, if: :validate_title?
     validates :start_date_day, presence: true, if: :validate_start_and_end_dates?
@@ -32,6 +35,7 @@ class Project < ApplicationRecord
     validates_with ProjectValidator, if: :validate_no_errors && :validate_start_and_end_dates?
 
     validates :project_title, presence: true, length: { maximum: 255 }, if: :validate_title?
+    validates :same_location, presence: true, if: :validate_same_location?
     validates :description, presence: true, if: :validate_description?
     validate :validate_description_length, if: :validate_description?
 
@@ -45,6 +49,10 @@ class Project < ApplicationRecord
 
     def validate_no_errors?
         self.errors.empty?
+    end
+
+    def validate_same_location?
+        validate_same_location == true
     end
 
     def validate_description?

--- a/app/views/project/project_location/project_location.html.erb
+++ b/app/views/project/project_location/project_location.html.erb
@@ -1,39 +1,45 @@
-<div>
-  <div>
-    <h2 class="govuk-heading-m" aria-label="Heading">About your project</h2>
-  </div>
-  <form action="/3-10k/project/save-location" method="post">
-    <%= hidden_field_tag :authenticity_token, form_authenticity_token, id: :form_token %>
-    <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset" aria-describedby="same-location-hint">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <h1 class="govuk-fieldset__heading">
-            Is the project taking place at the same location as your organisations address?
-          </h1>
-        </legend>
-        <div class="govuk-radios">
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="same-location" name="same-location" type="radio" value="yes">
-            <label class="govuk-label govuk-radios__label" for="same-location">
-              Yes
-            </label>
-          </div>
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="same-location-2" name="same-location" type="radio" value="no">
-            <label class="govuk-label govuk-radios__label" for="same-location-2">
-              No
-            </label>
-          </div>
+<%= render partial: "partials/summary_errors", locals: {
+    form_object: @project,
+    first_form_element: :project_same_location_yes
+} if @project.errors.any? %>
+
+<%= form_for @project, url: three_to_ten_k_project_location_put_path, method: :put do |f| %>
+
+  <div class="govuk-form-group <%= "govuk-form-group--error" if @project.errors.any? %>">
+
+    <fieldset class="govuk-fieldset">
+
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+
+        <h1 class="govuk-fieldset__heading">
+          <span class="govuk-caption-xl">About your project</span>
+          Is the project taking place at the same location as your organisation's address?
+        </h1>
+
+      </legend>
+
+      <%= render partial: "partials/form_group_errors", locals: {form_object: @project} if @project.errors.any? %>
+
+      <div class="govuk-radios">
+
+        <div class="govuk-radios__item">
+          <%= f.radio_button :same_location, "yes", class: "govuk-radios__input" %>
+          <%= f.label :same_location_yes, "Yes", class: "govuk-label govuk-radios__label" %>
         </div>
-      </fieldset>
-    </div>
-    <button class="govuk-button" role="button" aria-label="save and continue button">Save and continue</button>
-  </form>
 
-  <!--TODO Remove the link when routing is concrete-->
-  <% if Rails.env.development? %>
-    <a href="/3-10k/project/location">skip to next page</a>
-  <% end %>
+        <div class="govuk-radios__item">
+          <%= f.radio_button :same_location, "no", class: "govuk-radios__input" %>
+          <%= f.label :same_location_yes, "No", class: "govuk-label govuk-radios__label" %>
+        </div>
 
-</div>
+      </div>
 
+
+    </fieldset>
+
+
+  </div>
+
+  <%= f.submit "Save and continue", class:'govuk-button', role: 'button', 'aria-label' => 'save and continue button' %>
+
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,8 @@ en-GB:
               blank: "Enter the month your project will end on"
             end_date_year:
               blank: "Enter the year your project will end on"
+            same_location:
+              blank: "Select whether or not your project will take place at the same location as your organisation"
             description:
               blank: "Enter a description of your project"
               too_long: "Project description must be 500 words or fewer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
       put ':project_id/key-dates', to: 'project_dates#update', as: :dates_put
 
       get ':project_id/location', to: 'project_location#project_location', as: :location_get
+      put ':project_id/location', to: 'project_location#update', as: :location_put
 
       get ':project_id/description', to: 'project_description#show', as: :description_get
       put ':project_id/description', to: 'project_description#update', as: :description_put


### PR DESCRIPTION
This pull request adds the functionality for being able to specify that a project location is taking place in the same place as the corresponding organisation address.

I'll be picking up the inverse functionality in a separate branch and pull request.