### PR TITLE
Added a migration to add difference column to projects table

### DIFF
--- a/db/migrate/20200103090702_add_difference_to_projects.rb
+++ b/db/migrate/20200103090702_add_difference_to_projects.rb
@@ -1,0 +1,5 @@
+class AddDifferenceToProjects < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :difference, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_02_152101) do
+ActiveRecord::Schema.define(version: 2020_01_03_090702) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 2020_01_02_152101) do
     t.string "townCity"
     t.string "county"
     t.string "postcode"
+    t.text "difference"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 


### PR DESCRIPTION
This pull request adds a migration to add a `difference` column to the `projects` table, relevant to the 'What difference will your project make?' page.