### PR TITLE
Added migration file for adding matter column to projects table

### DIFF
--- a/db/migrate/20200103104247_add_matter_to_projects.rb
+++ b/db/migrate/20200103104247_add_matter_to_projects.rb
@@ -1,0 +1,5 @@
+class AddMatterToProjects < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :matter, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_03_090702) do
+ActiveRecord::Schema.define(version: 2020_01_03_104247) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 2020_01_03_090702) do
     t.string "county"
     t.string "postcode"
     t.text "difference"
+    t.text "matter"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 


### PR DESCRIPTION
This pull request adds a new migration script to add a `matter` column to the `projects` table. This is in relation to the 'Why does your project matter' page in the journey.