### PR TITLE
Removed usage of flash.notice on project dates page

### DIFF
--- a/app/controllers/project/project_dates_controller.rb
+++ b/app/controllers/project/project_dates_controller.rb
@@ -34,7 +34,7 @@ class Project::ProjectDatesController < ApplicationController
 
         logger.debug "Displaying project length warning for project ID: #{@project.id}"
 
-        flash.notice = "You can still submit your application if the start " +
+        flash[:date_warning] = "You can still submit your application if the start " +
             "and end dates are over one year but this can affect assessment."
 
         render :show

--- a/app/views/project/project_dates/show.html.erb
+++ b/app/views/project/project_dates/show.html.erb
@@ -15,13 +15,13 @@
       When will your project happen?
     </h1>
 
-    <% if flash.notice %>
+    <% if flash[:date_warning] %>
 
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
           <span class="govuk-warning-text-assistive">Warning</span>
-          <%= flash.notice %>
+          <%= flash[:date_warning] %>
         </strong>
       </div>
 


### PR DESCRIPTION
> I think this is causing this issue on a subsequent page, where the notice is being retained and displayed erroneously here. CC @stuartmccoll
> <img alt="Screenshot 2020-01-03 at 10 45 29" width="584" src="https://user-images.githubusercontent.com/1764158/71719457-521cd180-2e16-11ea-9717-8d83550d0748.png">

This fixes the above issue referenced in #62.

Note that we'll have to avoid using the built-in `flash` keys as these are used within the registration/login flow.