### PR TITLE
Added migration for heritage_description column of projects table

### DIFF
--- a/db/migrate/20200103145613_add_heritage_description_to_projects.rb
+++ b/db/migrate/20200103145613_add_heritage_description_to_projects.rb
@@ -1,0 +1,5 @@
+class AddHeritageDescriptionToProjects < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :heritage_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_03_123718) do
+ActiveRecord::Schema.define(version: 2020_01_03_145613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -102,6 +102,7 @@ ActiveRecord::Schema.define(version: 2020_01_03_123718) do
     t.string "postcode"
     t.text "difference"
     t.text "matter"
+    t.text "heritage_description"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 


### PR DESCRIPTION
This pull request includes a migration which adds a `heritage_description` column to the `projects` table - this is relevant to the 'The heritage of your project: how do you plan to make it available once the project is over?' page of the service journey.