### PR TITLE
Added migration for best_place_description column

### DIFF
--- a/db/migrate/20200106080153_add_best_placed_description_to_projects.rb
+++ b/db/migrate/20200106080153_add_best_placed_description_to_projects.rb
@@ -1,0 +1,5 @@
+class AddBestPlacedDescriptionToProjects < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :best_placed_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_03_145614) do
+ActiveRecord::Schema.define(version: 2020_01_06_080153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(version: 2020_01_03_145614) do
     t.text "difference"
     t.text "matter"
     t.text "heritage_description"
+    t.text "best_placed_description"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 


### PR DESCRIPTION
This migration script adds the best_placed_description column to the projects table. This is related to the 'Why is your organisation best placed to deliver this project' page of the service journey.