### PR TITLE
Add involvement_description migration for projects table

### DIFF
--- a/db/migrate/20200106100540_add_involvement_description_to_projects.rb
+++ b/db/migrate/20200106100540_add_involvement_description_to_projects.rb
@@ -1,0 +1,5 @@
+class AddInvolvementDescriptionToProjects < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :involvement_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_06_080153) do
+ActiveRecord::Schema.define(version: 2020_01_06_100540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -104,6 +104,7 @@ ActiveRecord::Schema.define(version: 2020_01_06_080153) do
     t.text "matter"
     t.text "heritage_description"
     t.text "best_placed_description"
+    t.text "involvement_description"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 


### PR DESCRIPTION
This commit adds a migrations script to add the involvement_description column to the projects table. This is related to the 'How will your project involve a wider range of people?' page of the service journey.