### PR TITLE
Added migration script for project permission columns

### DIFF
--- a/db/migrate/20200107095122_add_permission_to_projects.rb
+++ b/db/migrate/20200107095122_add_permission_to_projects.rb
@@ -1,0 +1,6 @@
+class AddPermissionToProjects < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :permission_type, :integer
+    add_column :projects, :permission_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_06_101655) do
+ActiveRecord::Schema.define(version: 2020_01_07_095122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -105,6 +105,8 @@ ActiveRecord::Schema.define(version: 2020_01_06_101655) do
     t.text "heritage_description"
     t.text "best_placed_description"
     t.text "involvement_description"
+    t.integer "permission_type"
+    t.text "permission_description"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 


### PR DESCRIPTION
This commit adds a migration script to add two new columns to the projects database. These are `permission_type`, which will be used to determine the type of permission selected by a user that their project requires, and `permission_description` which will be used to store details of the permission required by their project.