### PR TITLE
download CF CLI from S3 and install from .deb file

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -41,11 +41,8 @@ jobs:
     - name: Install the CF CLI
       if: github.ref == 'refs/heads/master'
       run: |
-        wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
-        echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-        sudo apt-get update
-        sudo apt-get install -y cf-cli
-    
+        wget https://s3-us-west-1.amazonaws.com/cf-cli-releases/releases/v6.48.0/cf-cli-installer_6.48.0_x86-64.deb
+        sudo dpkg -i cf-cli-installer_6.48.0_x86-64.deb
     - name: Deploy
       if: github.ref == 'refs/heads/master'
       env:


### PR DESCRIPTION
Workaround for upstream issue https://github.community/t5/GitHub-Actions/Errors-on-updating-apt-cache-for-azure-cli/m-p/42743#M5095