### PR TITLE
Display account error and info messages.

### DIFF
--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,4 +1,4 @@
-<% if resource.errors.any? %>
+<% if resource.errors.any?  || flash[:alert].present? %>
 <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">
       <%= I18n.t(
@@ -8,6 +8,7 @@
        %>
   </h2>
   <div class="govuk-error-summary__body">
+    <%= flash[:alert] %>
     <ul class="govuk-list govuk-error-summary__list">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,3 +1,5 @@
+
+<%= content_tag(:h1, flash[:notice]) if flash[:notice].present? %> <%#TODO: Style this for notification messages %>
 <% if resource.errors.any?  || flash[:alert].present? %>
 <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">


### PR DESCRIPTION
This displays errors and notifications and errors from devise.
Fixes #62 
@paulmsmith we need to handle the information messages generated by devise. For now I added them in the error area unstyled but they may be more suited to an overlay style or something which denotes success.. 
Please can you figure out a design for this.
![Screenshot 2020-01-07 at 13 16 03](https://user-images.githubusercontent.com/1764158/71898223-a692ba80-3150-11ea-8a24-cf25ac6b224b.png)

