### PR TITLE
Added a migration script for capital_work column to projects table

### DIFF
--- a/db/migrate/20200107154043_add_capital_work_to_projects.rb
+++ b/db/migrate/20200107154043_add_capital_work_to_projects.rb
@@ -1,0 +1,6 @@
+class AddCapitalWorkToProjects < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :capital_work, :boolean
+    add_column :projects, :capital_work_supporting_document, :string
+  end
+end

--- a/db/migrate/20200107154043_add_capital_work_to_projects.rb
+++ b/db/migrate/20200107154043_add_capital_work_to_projects.rb
@@ -1,6 +1,5 @@
 class AddCapitalWorkToProjects < ActiveRecord::Migration[6.0]
   def change
     add_column :projects, :capital_work, :boolean
-    add_column :projects, :capital_work_supporting_document, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -108,7 +108,6 @@ ActiveRecord::Schema.define(version: 2020_01_07_154043) do
     t.integer "permission_type"
     t.text "permission_description"
     t.boolean "capital_work"
-    t.string "capital_work_supporting_document"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_07_095122) do
+ActiveRecord::Schema.define(version: 2020_01_07_154043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -107,6 +107,8 @@ ActiveRecord::Schema.define(version: 2020_01_07_095122) do
     t.text "involvement_description"
     t.integer "permission_type"
     t.text "permission_description"
+    t.boolean "capital_work"
+    t.string "capital_work_supporting_document"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 


### PR DESCRIPTION
This commit adds a migrations script containing a new column to the projects table - `capital_work` is a boolean column to indicate whether or not capital work will be part of a project.