### PR TITLE
Updated to_salesforce_json method of project model

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -166,6 +166,67 @@ class Project < ApplicationRecord
                 json.set!('username', self.user.email)
             end
             json.application do
+                json.set!('projectName', self.project_title)
+                json.projectDateRange do
+                    json.startDate self.start_date
+                    json.endDate self.end_date
+                end
+                json.projectAddress do
+                    json.line1 self.line1
+                    json.line2 self.line2
+                    json.line3 self.line3
+                    json.county self.county
+                    json.townCity self.townCity
+                    json.projectPostcode self.postcode
+                end
+                json.set!('yourIdeaProject', self.description)
+                json.set!('projectDifference', self.difference)
+                json.set!('projectCommunity', self.matter)
+                json.set!('projectOrgBestPlace', self.best_placed_description)
+                json.set!('projectAvailable', self.heritage_description)
+                json.set!('projectOutcome1', 'Dummy data')
+                json.set!('projectOutcome2', 'Dummy data')
+                json.set!('projectOutcome3', 'Dummy data')
+                json.set!('projectOutcome4', 'Dummy data')
+                json.set!('projectOutcome5', 'Dummy data')
+                json.set!('projectOutcome6', 'Dummy data')
+                json.set!('projectOutcome7', 'Dummy data')
+                json.set!('projectOutcome8', 'Dummy data')
+                json.set!('projectOutcome9', 'Dummy data')
+                json.set!('projectOutcome1Checked', true)
+                json.set!('projectOutcome2Checked', true)
+                json.set!('projectOutcome3Checked', true)
+                json.set!('projectOutcome4Checked', true)
+                json.set!('projectOutcome5Checked', true)
+                json.set!('projectOutcome6Checked', true)
+                json.set!('projectOutcome7Checked', true)
+                json.set!('projectOutcome8Checked', true)
+                json.set!('projectOutcome9Checked', true)
+                json.projectCosts do
+                    json.costId 'baa49446-cb70-46c7-ade1-0e17ad450c8a'
+                    json.costType 'new-staff'
+                    json.costDescription 'Dummy data'
+                    json.costAmount '1000'
+                end
+                json.projectVolunteers do
+                    json.description 'Dummy data'
+                    json.hours 10
+                end
+                json.nonCashContributions do
+                    json.description 'Dummy data'
+                    json.estimatedValue 1000
+                    json.secured 'not-sure'
+                end
+                json.cashContributions do
+                    json.description 'Dummy data'
+                    json.amount 2000
+                    json.secured 'no'
+                    json.id 'c4237718-ced7-4d03-a95b-1eceaecfdbe0'
+                end
+                json.evidenceOfSupport do
+                    json.description 'Dummy data'
+                end
+                json.set!('organisationId', self.organisation.id)
                 json.set!('organisationName', self.organisation.name)
                 json.set!('organisationMission',
                           self.organisation.mission.map!(&:dasherize).map { |m| m == 'lgbt-plus-led' ? 'lgbt+-led' : m })

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -203,28 +203,33 @@ class Project < ApplicationRecord
                 json.set!('projectOutcome8Checked', true)
                 json.set!('projectOutcome9Checked', true)
                 json.projectCosts do
-                    json.costId 'baa49446-cb70-46c7-ade1-0e17ad450c8a'
-                    json.costType 'new-staff'
-                    json.costDescription 'Dummy data'
-                    json.costAmount '1000'
+                    json.child! {
+                        json.costId 'baa49446-cb70-46c7-ade1-0e17ad450c8a'
+                        json.costType 'new-staff'
+                        json.costDescription 'Dummy data'
+                        json.costAmount '1000'
+                    }
                 end
                 json.projectVolunteers do
-                    json.description 'Dummy data'
-                    json.hours 10
+                    json.child! {
+                        json.description 'Dummy data'
+                        json.hours 10
+                    }
                 end
                 json.nonCashContributions do
-                    json.description 'Dummy data'
-                    json.estimatedValue 1000
-                    json.secured 'not-sure'
+                    json.child! {
+                        json.description 'Dummy data'
+                        json.estimatedValue 1000
+                        json.secured 'not-sure'
+                    }
                 end
                 json.cashContributions do
-                    json.description 'Dummy data'
-                    json.amount 2000
-                    json.secured 'no'
-                    json.id 'c4237718-ced7-4d03-a95b-1eceaecfdbe0'
-                end
-                json.evidenceOfSupport do
-                    json.description 'Dummy data'
+                    json.child! {
+                        json.description 'Dummy data'
+                        json.amount 2000
+                        json.secured 'no'
+                        json.id 'c4237718-ced7-4d03-a95b-1eceaecfdbe0'
+                    }
                 end
                 json.set!('organisationId', self.organisation.id)
                 json.set!('organisationName', self.organisation.name)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -184,7 +184,7 @@ class Project < ApplicationRecord
                 json.set!('projectCommunity', self.matter)
                 json.set!('projectOrgBestPlace', self.best_placed_description)
                 json.set!('projectAvailable', self.heritage_description)
-                json.set!('projectOutcome1', 'Dummy data')
+                json.set!('projectOutcome1', self.involvement_description)
                 json.set!('projectOutcome2', 'Dummy data')
                 json.set!('projectOutcome3', 'Dummy data')
                 json.set!('projectOutcome4', 'Dummy data')

--- a/test/fixtures/organisations.yml
+++ b/test/fixtures/organisations.yml
@@ -14,7 +14,8 @@ one: {
                  "young_people_led"],
        org_type: 0,
        line1: 'line 1',
-       charity_number: 123,
+       charity_number: 12345,
+       company_number: 54321,
        townCity: "town"
 }
 # column: value

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -4,7 +4,23 @@
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: 
-  id: '2c660111-ab15-4221-98e0-cf0e02748a9b'
-  user_id: 1
+one: {
+  id: '2c660111-ab15-4221-98e0-cf0e02748a9b',
+  user_id: 1,
+  project_title: "Test Project",
+  start_date: "1/1/2025",
+  end_date: "1/10/2025",
+  line1: "10 Downing Street",
+  line2: "Westminster",
+  townCity: "London",
+  county: "Greater London",
+  postcode: "SW1A 2AA",
+  description: "A description of my project...",
+  difference: "The difference my project will make to...",
+  matter: "My project matters because...",
+  best_placed_description: "My organisation is best placed to...",
+  heritage_description: "The heritage of my project...",
+  involvement_description: "My project will involve a wider range of people..."
+}
+
 

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -2,17 +2,41 @@ require 'test_helper'
 
 class ProjectTest < ActiveSupport::TestCase
    test "serialises Salesforce JSON" do
-     @project = projects(:one)
-     @project_salesforce_json_obj = JSON.parse(@project.to_salesforce_json)
+     @project_salesforce_json_obj = JSON.parse(projects(:one).to_salesforce_json)
+
+     # Assert meta parameters
      assert_equal  '2c660111-ab15-4221-98e0-cf0e02748a9b', @project_salesforce_json_obj['meta']['applicationId']
      assert_equal 'test@example.com', @project_salesforce_json_obj['meta']['username']
+
+     # Assert organisation parameters
      assert_equal 'test organisation', @project_salesforce_json_obj['application']['organisationName']
      assert_equal 'registered-charity', @project_salesforce_json_obj['application']['organisationType']
      assert_equal 'line 1', @project_salesforce_json_obj['application']['organisationAddress']['line1']
      assert_equal 'town', @project_salesforce_json_obj['application']['organisationAddress']['townCity']
      assert_equal 'John Doe', @project_salesforce_json_obj['application']['authorisedSignatoryOneDetails']['name']
      assert_equal 'Jane Doe', @project_salesforce_json_obj['application']['authorisedSignatoryTwoDetails']['name']
-     assert_equal '123', @project_salesforce_json_obj['application']['charityNumber']
-     assert_equal %w(black-or-minority-ethnic-led disability-led lgbt+-led female-led young-people-led), @project_salesforce_json_obj['application']['organisationMission']
+     assert_equal '12345', @project_salesforce_json_obj['application']['charityNumber']
+     assert_equal '54321', @project_salesforce_json_obj['application']['companyNumber']
+     assert_equal %w(black-or-minority-ethnic-led disability-led lgbt+-led female-led young-people-led),
+                  @project_salesforce_json_obj['application']['organisationMission']
+
+     # Assert project parameters
+     assert_equal 'Test Project', @project_salesforce_json_obj['application']['projectName']
+     assert_equal '2025-01-01', @project_salesforce_json_obj['application']['projectDateRange']['startDate']
+     assert_equal '2025-10-01', @project_salesforce_json_obj['application']['projectDateRange']['endDate']
+     assert_equal '10 Downing Street', @project_salesforce_json_obj['application']['projectAddress']['line1']
+     assert_equal 'Westminster', @project_salesforce_json_obj['application']['projectAddress']['line2']
+     assert_equal 'London', @project_salesforce_json_obj['application']['projectAddress']['townCity']
+     assert_equal 'Greater London', @project_salesforce_json_obj['application']['projectAddress']['county']
+     assert_equal 'SW1A 2AA', @project_salesforce_json_obj['application']['projectAddress']['projectPostcode']
+     assert_equal 'A description of my project...', @project_salesforce_json_obj['application']['yourIdeaProject']
+     assert_equal 'The difference my project will make to...',
+                  @project_salesforce_json_obj['application']['projectDifference']
+     assert_equal 'My project matters because...', @project_salesforce_json_obj['application']['projectCommunity']
+     assert_equal 'My organisation is best placed to...',
+                  @project_salesforce_json_obj['application']['projectOrgBestPlace']
+     assert_equal 'The heritage of my project...', @project_salesforce_json_obj['application']['projectAvailable']
+     assert_equal 'My project will involve a wider range of people...',
+                  @project_salesforce_json_obj['application']['projectOutcome1']
    end
 end


### PR DESCRIPTION
This pull request adds some of the missing model fields to the `to_salesforce_json` method for the `project` model, with dummy data and real data where this is available.