### PR TITLE
Added project outcomes migration script

### DIFF
--- a/db/migrate/20200109142055_add_outcomes_to_projects.rb
+++ b/db/migrate/20200109142055_add_outcomes_to_projects.rb
@@ -1,0 +1,21 @@
+class AddOutcomesToProjects < ActiveRecord::Migration[6.0]
+  def change
+
+    add_column :projects, :outcome_2, :boolean
+    add_column :projects, :outcome_3, :boolean
+    add_column :projects, :outcome_4, :boolean
+    add_column :projects, :outcome_5, :boolean
+    add_column :projects, :outcome_6, :boolean
+    add_column :projects, :outcome_7, :boolean
+    add_column :projects, :outcome_8, :boolean
+
+    add_column :projects, :outcome_2_description, :text
+    add_column :projects, :outcome_3_description, :text
+    add_column :projects, :outcome_4_description, :text
+    add_column :projects, :outcome_5_description, :text
+    add_column :projects, :outcome_6_description, :text
+    add_column :projects, :outcome_7_description, :text
+    add_column :projects, :outcome_8_description, :text
+
+  end
+end

--- a/db/migrate/20200109142055_add_outcomes_to_projects.rb
+++ b/db/migrate/20200109142055_add_outcomes_to_projects.rb
@@ -8,6 +8,7 @@ class AddOutcomesToProjects < ActiveRecord::Migration[6.0]
     add_column :projects, :outcome_6, :boolean
     add_column :projects, :outcome_7, :boolean
     add_column :projects, :outcome_8, :boolean
+    add_column :projects, :outcome_9, :boolean
 
     add_column :projects, :outcome_2_description, :text
     add_column :projects, :outcome_3_description, :text
@@ -16,6 +17,7 @@ class AddOutcomesToProjects < ActiveRecord::Migration[6.0]
     add_column :projects, :outcome_6_description, :text
     add_column :projects, :outcome_7_description, :text
     add_column :projects, :outcome_8_description, :text
+    add_column :projects, :outcome_9_description, :text
 
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_08_150358) do
+ActiveRecord::Schema.define(version: 2020_01_09_142055) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -112,6 +112,20 @@ ActiveRecord::Schema.define(version: 2020_01_08_150358) do
     t.text "declaration_reasons_description"
     t.boolean "user_research_declaration", default: false
     t.boolean "keep_informed_declaration", default: false
+    t.boolean "outcome_2"
+    t.boolean "outcome_3"
+    t.boolean "outcome_4"
+    t.boolean "outcome_5"
+    t.boolean "outcome_6"
+    t.boolean "outcome_7"
+    t.boolean "outcome_8"
+    t.text "outcome_2_description"
+    t.text "outcome_3_description"
+    t.text "outcome_4_description"
+    t.text "outcome_5_description"
+    t.text "outcome_6_description"
+    t.text "outcome_7_description"
+    t.text "outcome_8_description"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -119,6 +119,7 @@ ActiveRecord::Schema.define(version: 2020_01_09_142055) do
     t.boolean "outcome_6"
     t.boolean "outcome_7"
     t.boolean "outcome_8"
+    t.boolean "outcome_9"
     t.text "outcome_2_description"
     t.text "outcome_3_description"
     t.text "outcome_4_description"
@@ -126,6 +127,7 @@ ActiveRecord::Schema.define(version: 2020_01_09_142055) do
     t.text "outcome_6_description"
     t.text "outcome_7_description"
     t.text "outcome_8_description"
+    t.text "outcome_9_description"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 


### PR DESCRIPTION
This commit adds a new migration script containing the eight `boolean` columns for each outcome on the project outcomes page, as well as the eight `text` columns for the relating descriptions.