### PR TITLE
Cache gemfile dependencies

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -28,7 +28,17 @@ jobs:
         ruby-version: '2.6.x'
     - run: yarn install
     - run: gem install bundler
-    - run: bundle install
+    - name: Cache Gemfile dependencies
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems
+    - name: Bundle install
+      run: |
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
     - name: Run tests 
       env:
         PGHOST: localhost


### PR DESCRIPTION
We can speed up the build by using the new caching ability provided by GitHub actions to cache dependencies.
See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows for context.