### PR TITLE
Updated routes to fix sign-in error message display

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,14 @@
 Rails.application.routes.draw do
 
+  devise_scope :user do
+    unauthenticated do
+      root to: "devise/sessions#new"
+    end
+    authenticated :user do
+      root to: "dashboard#show", as: :authenticated_root
+    end
+  end
+
   namespace :account do
     get 'create-new-account' => 'account#new'
     get 'account-created' => 'account#account_created'
@@ -124,7 +133,6 @@ Rails.application.routes.draw do
 
   devise_for :users
   resources :projects, except: [:destroy, :index]
-  root to: "dashboard#show"
   get 'start-a-project', to: 'home#show', as: :start_a_project
   get 'logout' => 'logout#logout'
   post 'consumer' => 'released_form#receive' do

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class HomeControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get root_url
-    assert_response :redirect
+    assert_response :success
   end
 
 end


### PR DESCRIPTION
This pull request updates the root of the application to point at two different pages depending on whether or not a user has authenticated. Unauthenticated users are directed to the sign-in page, authenticated users are directed to the dashboard page.

Previously, we were directing all root requests to the dashboard page. When a user wasn't signed in, this would trigger the fact that the user wasn't authenticated and then direct them back to the sign-in page with the 'You must be signed in...' error message displayed.

I've tested, and this *does* also fix the email validation confirmation being displayed.