### PR TITLE
Remove duplicate autofocus attribute

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -13,7 +13,7 @@
 
   <div class="govuk-form-group">
     <%= f.label :password, class: "govuk-label" %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "govuk-input govuk-input--width-20" %>
+    <%= f.password_field :password, autocomplete: "new-password", class: "govuk-input govuk-input--width-20" %>
   </div>
 
   <div class="govuk-form-group">


### PR DESCRIPTION
I noticed during accessibility testing that the password input field on the new account creation page was gaining autofocus when the page initially loaded. Upon inspection, it looks like we were setting autofocus to true on both the email_field and password_field elements. This commit fixes the issue by removing the autofocus attribute from the password_field element.