### PR TITLE
Added validation to project volunteers page

### DIFF
--- a/app/controllers/project/project_volunteers_controller.rb
+++ b/app/controllers/project/project_volunteers_controller.rb
@@ -2,14 +2,35 @@ class Project::ProjectVolunteersController < ApplicationController
   include ProjectContext
 
   def put
-    #TODO: Add validation
+
+    # Empty flash values to ensure that we don't redisplay them unnecessarily
+    flash[:description] = ""
+    flash[:hours] = ""
+
+    logger.debug "Adding volunteer for project ID: #{@project.id}"
+
+    @project.validate_volunteers = true
+
     @project.update(project_params)
-    redirect_to three_to_ten_k_project_volunteers_path
-  end
 
+    if @project.valid?
 
-  def show
-    @volunteer = @project.volunteers.build
+      logger.debug "Successfully added volunteer for project ID: #{@project.id}"
+
+      redirect_to three_to_ten_k_project_volunteers_path
+
+    else
+
+      logger.debug "Validation failed when adding volunteer for project ID: #{@project.id}"
+
+      # Store flash values to display them again when re-rendering the page
+      flash[:description] = params['project']['volunteers_attributes']['0']['description']
+      flash[:hours] = params['project']['volunteers_attributes']['0']['hours']
+
+      render :show
+
+    end
+
   end
 
   private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -13,6 +13,7 @@ class Project < ApplicationRecord
     accepts_nested_attributes_for :cash_contributions, :non_cash_contributions, :project_costs, :volunteers
 
     validates_associated :non_cash_contributions, if: :validate_non_cash_contributions?
+    validates_associated :volunteers, if: :validate_volunteers?
 
     attr_accessor :validate_title
     attr_accessor :validate_start_and_end_dates
@@ -31,6 +32,7 @@ class Project < ApplicationRecord
     attr_accessor :validate_involvement_description
     attr_accessor :validate_other_outcomes
     attr_accessor :validate_non_cash_contributions
+    attr_accessor :validate_volunteers
     attr_accessor :validate_cash_contributions_question
     attr_accessor :validate_confirm_declaration
 
@@ -235,6 +237,10 @@ class Project < ApplicationRecord
 
     def validate_non_cash_contributions?
         validate_non_cash_contributions == true
+    end
+
+    def validate_volunteers?
+        validate_volunteers == true
     end
 
     def validate_confirm_declaration?

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -1,3 +1,6 @@
 class Volunteer < ApplicationRecord
   belongs_to :project
+
+  validates :description, presence: true
+  validates :hours, numericality: {only_integer: true}
 end

--- a/app/views/project/project_volunteers/show.html.erb
+++ b/app/views/project/project_volunteers/show.html.erb
@@ -107,6 +107,7 @@
 
               <%= v.label :description, class: 'govuk-label' %>
               <%= v.text_area :description,
+                              required: true,
                               class: "govuk-textarea #{'govuk-textarea--error' if @project.errors['volunteers.description'].any?} govuk-js-character-count",
                               rows: 5,
                               value: "#{flash[:description] if flash[:description].present?}"
@@ -125,6 +126,7 @@
 
             <%= v.label :hours, class: 'govuk-label' %>
             <%= v.number_field :hours,
+                               required: true,
                                min: 1,
                                class: "govuk-input govuk-input govuk-input--width-10 #{'govuk-input--error' if @project.errors['volunteers.hours'].any?}",
                                value: "#{flash[:hours] if flash[:hours].present?}"

--- a/app/views/project/project_volunteers/show.html.erb
+++ b/app/views/project/project_volunteers/show.html.erb
@@ -1,63 +1,92 @@
-<%=content_for :page_title, "Volunteers" %>
+<% content_for :page_title, @project.errors.any? ? "Error: Volunteers" : "Volunteers" %>
 
-  <span class="govuk-caption-xl">Support for your project</span>
-  <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">Volunteers</h1>
-  <p class="govuk-body-l govuk-!-margin-bottom-9">Tell us what you already have in place to support your project.</p>
+<%# TODO: Split this into a partial %>
+<% if @project.errors.any? %>
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
 
-  <section class="nlhf-summary govuk-!-margin-bottom-9">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
 
-    <header class="nlhf-summary__header">
-      <h2 class="govuk-heading-m">Your project volunteers</h2>
-    </header>
+    <div class="govuk-error-summary__body">
 
-    <div class="nlhf-summary__body">
-    
-      <% unless @project.volunteers.first&.id.present? %>
-          
-          <h3 class="govuk-heading-m govuk-!-margin-bottom-0">You have not added any volunteers</h3>
+      <ul class="govuk-list govuk-error-summary__list">
 
-      <% else %>
-
-        <table class="govuk-table">
-          
-          <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th scope="col" class="govuk-table__header">Description</th>
-              <th scope="col" class="govuk-table__header govuk-table__header--numeric">Hours</th>
-            </tr>
-          </thead>
-
-          <tbody class="govuk-table__body">
-
-            <% @project.volunteers.where.not(id: nil).each do |v| %>
-              <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><%= v.description %></td>
-                <td class="govuk-table__cell govuk-table__cell--numeric"><%= v.hours %></td>
-              </tr>
-            <% end %>
-
-          </tbody>
-        </table>
-
-        <div class="nlhf-summary__total">
-            <h3 class="nlhf-summary__total__title">
-                <span class="nlhf-summary__total__title-text">Total hours </span>
-                <span class="nlhf-summary__total__title-val"><%= calculate_volunteer_total(@project.volunteers) %></span>
-            </h3>
-        </div>
-
+        <% @project.errors.each do |attr, msg| %>
+          <% unless attr.to_s == "volunteers" %>
+            <li>
+              <a data-turbolinks='false' href='#project_volunteers_attributes_0_<%= "#{attr.to_s.split('.')[1]}" %>'>
+                <%= msg %>
+              </a>
+            </li>
+          <% end %>
         <% end %>
 
+      </ul>
+
     </div>
-    <!-- /.nlhf-summary__body -->
 
-  </section>
+  </div>
+<% end %>
 
-  <%= form_with model: @project, url: three_to_ten_k_project_volunteers_path, method: :put do |f| %>
-    <% f.fields_for :volunteers, @volunteer do |v| %>
+<span class="govuk-caption-xl">Support for your project</span>
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-2">Volunteers</h1>
+<p class="govuk-body-l govuk-!-margin-bottom-9">Tell us what you already have in place to support your project.</p>
+
+<section class="nlhf-summary govuk-!-margin-bottom-9">
+
+  <header class="nlhf-summary__header">
+    <h2 class="govuk-heading-m">Your project volunteers</h2>
+  </header>
+
+  <div class="nlhf-summary__body">
+
+    <% unless @project.volunteers.first&.id.present? %>
+
+      <h3 class="govuk-heading-m govuk-!-margin-bottom-0">You have not added any volunteers</h3>
+
+    <% else %>
+
+      <table class="govuk-table">
+
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Description</th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">Hours</th>
+        </tr>
+        </thead>
+
+        <tbody class="govuk-table__body">
+
+        <% @project.volunteers.where.not(id: nil).each do |v| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= v.description %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= v.hours %></td>
+          </tr>
+        <% end %>
+
+        </tbody>
+      </table>
+
+      <div class="nlhf-summary__total">
+        <h3 class="nlhf-summary__total__title">
+          <span class="nlhf-summary__total__title-text">Total hours </span>
+          <span class="nlhf-summary__total__title-val"><%= calculate_volunteer_total(@project.volunteers) %></span>
+        </h3>
+      </div>
+
+    <% end %>
+
+  </div>
+  <!-- /.nlhf-summary__body -->
+
+</section>
+
+<%= form_with model: @project, url: three_to_ten_k_project_volunteers_path, method: :put, local: true do |f| %>
+  <% f.fields_for :volunteers, @project.volunteers.build do |v| %>
 
     <div class="nlhf-add-item govuk-!-margin-bottom-9">
-      
+
       <header class="nlhf-add-item__header">
         <h2 class="govuk-heading-l">Add a volunteer</h2>
       </header>
@@ -65,21 +94,42 @@
       <div class="nlhf-add-item__body">
 
         <p class="govuk-body govuk-!-margin-bottom-6">Volunteers are people who give up their time for free to help deliver your project.</p>
-        
+
         <div class="nlhf-add-item__row">
+
           <div class="govuk-character-count" data-module="govuk-character-count" data-maxwords="50">
-            <div class="govuk-form-group">
+
+            <div class="govuk-form-group <%= "govuk-form-group--error" if @project.errors['volunteers.description'].any? %>">
+
+              <%= render partial: "partials/form_input_errors",
+                         locals: {form_object: @project,
+                                  input_field_id: :'volunteers.description'} if @project.errors['volunteers.description'].any? %>
+
               <%= v.label :description, class: 'govuk-label' %>
-              <%= v.text_area :description, class: 'govuk-textarea govuk-js-character-count', rows: 5 %>
+              <%= v.text_area :description,
+                              class: "govuk-textarea #{'govuk-textarea--error' if @project.errors['volunteers.description'].any?} govuk-js-character-count",
+                              rows: 5,
+                              value: "#{flash[:description] if flash[:description].present?}"
+              %>
               <span id="<%= v.object_name.gsub(/[\[\]]+/, '_').chop + '_description-info' %>" class="govuk-hint govuk-character-count__message" aria-live="polite">You have 50 words remaining</span>
             </div>
           </div>
         </div>
 
         <div class="nlhf-add-item__row">
-          <div class="govuk-form-group">
+          <div class="govuk-form-group <%= "govuk-form-group--error" if @project.errors['volunteers.hours'].any? %>">
+
+            <%= render partial: "partials/form_input_errors",
+                       locals: {form_object: @project,
+                                input_field_id: :'volunteers.hours'} if @project.errors['volunteers.hours'].any? %>
+
             <%= v.label :hours, class: 'govuk-label' %>
-            <%= v.number_field :hours, class: 'govuk-input govuk-input govuk-input--width-10' %>
+            <%= v.number_field :hours,
+                               min: 1,
+                               class: "govuk-input govuk-input govuk-input--width-10 #{'govuk-input--error' if @project.errors['volunteers.hours'].any?}",
+                               value: "#{flash[:hours] if flash[:hours].present?}"
+            %>
+
           </div>
         </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,3 +94,9 @@ en-GB:
               blank: "Enter a description of your non-cash contribution"
             amount:
               not_a_number: "Amount must be a number, like 500"
+        volunteer:
+          attributes:
+            description:
+              blank: "Enter a description of your project volunteer"
+            hours:
+              not_a_number: "Hours must be a number, like 5"


### PR DESCRIPTION
This pull request adds validation to the project volunteers page. Note that this is done in the same way that we have done non-cash contributions, using `flash` to populate form values when we re-render upon validation failure, which we've said that we'll revisit when we have time.

I've also left in the `TODO` around splitting the summary of errors out into a partial, or refactoring the existing partial to be able to accommodate nested forms.