### PR TITLE
Added link to supporting evidence page Save and continue button

### DIFF
--- a/app/views/project/project_support_evidence/project_support_evidence.html.erb
+++ b/app/views/project/project_support_evidence/project_support_evidence.html.erb
@@ -103,6 +103,7 @@
 
 <p class="govuk-body">If you have finished adding all your evidence</p>
 
-<button data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">
+<a href="<%= "#{three_to_ten_k_project_check_answers_get_url}" %>" role="button" draggable="false" class="govuk-button"
+   data-module="govuk-button" aria-label="Continue button">
   Save and continue
-</button>
+</a>


### PR DESCRIPTION
This pull request adds functionality to the 'Save and continue' button on the 'Evidence of support' page.

Note that we've discussed investigating whether these should be form buttons or links with button roles, which has been raised in #140.