### PR TITLE
remove pry invocation

### DIFF
--- a/app/controllers/organisation/organisation_about_controller.rb
+++ b/app/controllers/organisation/organisation_about_controller.rb
@@ -1,5 +1,4 @@
 require 'ideal_postcodes'
-require 'pry'
 
 class Organisation::OrganisationAboutController < ApplicationController
   include OrganisationHelper


### PR DESCRIPTION
This is a debugging tool which is no longer included in the production dependencies causing the deploy to fail.