### PR TITLE
Replaced set_organisation helper use with a controller context

### DIFF
--- a/app/controllers/concerns/organisation_context.rb
+++ b/app/controllers/concerns/organisation_context.rb
@@ -1,0 +1,29 @@
+module OrganisationContext
+  extend ActiveSupport::Concern
+  included do
+    before_action :authenticate_user!, :set_organisation
+  end
+
+  # This method retrieves an organisation object based on the id
+  # found in the URL parameters and the current authenticated
+  # user's id, setting it as an instance variable for use in
+  # organisation-related controllers.
+  #
+  # If no organisation object matching the parameters is found,
+  # then the user is redirected to the projects dashboard.
+  #
+  # TODO: Write tests for this.
+  def set_organisation
+
+    authorised = false
+
+    if params[:organisation_id] == current_user.organisation&.id
+      @organisation = Organisation.find_by(id: params[:organisation_id])
+      authorised = @organisation.present?
+    end
+
+    redirect_to :authenticated_root if authorised == false
+
+  end
+
+end

--- a/app/controllers/concerns/organisation_context.rb
+++ b/app/controllers/concerns/organisation_context.rb
@@ -9,20 +9,18 @@ module OrganisationContext
   # user's id, setting it as an instance variable for use in
   # organisation-related controllers.
   #
-  # If no organisation object matching the parameters is found,
-  # then the user is redirected to the projects dashboard.
+  # If the user's organisation id and the organisation id param
+  # do not match, then the user is redirected to the projects
+  # dashboard
   #
   # TODO: Write tests for this.
   def set_organisation
 
-    authorised = false
-
-    if params[:organisation_id] == current_user.organisation&.id
-      @organisation = Organisation.find_by(id: params[:organisation_id])
-      authorised = @organisation.present?
+    unless params[:organisation_id] == current_user.organisation&.id
+      redirect_to :authenticated_root
+    else
+      @organisation = Organisation.find_by(id: current_user.organisation&.id)
     end
-
-    redirect_to :authenticated_root if authorised == false
 
   end
 

--- a/app/controllers/organisation/organisation_about_controller.rb
+++ b/app/controllers/organisation/organisation_about_controller.rb
@@ -1,8 +1,8 @@
 require 'ideal_postcodes'
 
 class Organisation::OrganisationAboutController < ApplicationController
-  include OrganisationHelper
-  before_action :set_api_key, :authenticate_user!, :set_organisation
+  include OrganisationContext
+  before_action :set_api_key
 
   # Renders the initial postcode lookup view
   def show_postcode_lookup

--- a/app/controllers/organisation/organisation_mission_controller.rb
+++ b/app/controllers/organisation/organisation_mission_controller.rb
@@ -1,6 +1,5 @@
 class Organisation::OrganisationMissionController < ApplicationController
-  include OrganisationHelper
-  before_action :authenticate_user!, :set_organisation
+  include OrganisationContext
 
   def show
     render :mission

--- a/app/controllers/organisation/organisation_numbers_controller.rb
+++ b/app/controllers/organisation/organisation_numbers_controller.rb
@@ -1,6 +1,5 @@
 class Organisation::OrganisationNumbersController < ApplicationController
-  include OrganisationHelper
-  before_action :authenticate_user!, :set_organisation
+  include OrganisationContext
 
   def show
     render :numbers

--- a/app/controllers/organisation/organisation_signatories_controller.rb
+++ b/app/controllers/organisation/organisation_signatories_controller.rb
@@ -1,6 +1,6 @@
 class Organisation::OrganisationSignatoriesController < ApplicationController
-  include OrganisationHelper
-  before_action :authenticate_user!, :set_organisation, :set_legal_signatories
+  include OrganisationContext
+  before_action :set_legal_signatories
 
   def show
     render :signatories

--- a/app/controllers/organisation/organisation_summary_controller.rb
+++ b/app/controllers/organisation/organisation_summary_controller.rb
@@ -1,8 +1,3 @@
 class Organisation::OrganisationSummaryController < ApplicationController
-  include OrganisationHelper
-  before_action :authenticate_user!, :set_organisation
-
-  def show
-  end
-
+  include OrganisationContext
 end

--- a/app/controllers/organisation/organisation_type_controller.rb
+++ b/app/controllers/organisation/organisation_type_controller.rb
@@ -1,6 +1,5 @@
 class Organisation::OrganisationTypeController < ApplicationController
-  include OrganisationHelper
-  before_action :authenticate_user!, :set_organisation
+  include OrganisationContext
 
   def show
     render :type

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -1,11 +1,2 @@
 module OrganisationHelper
-
-  # Helper method to set the organisation instance variable equal
-  # to the organisation of the current user
-  def set_organisation
-    if !@organisation.present?
-      @organisation = Organisation.find(current_user.organisation.id)
-    end
-  end
-
 end


### PR DESCRIPTION
Similar to how we replaced the `set_project` usage for project controllers, this pull request does the same for organisation controllers.

As well as that, it adds extra checks to ensure that the organisation which is being accessed is related to the current user.

Closes #155 