### PR TITLE
Split evidence of support into own model and added validation

### DIFF
--- a/app/controllers/project/project_support_evidence_controller.rb
+++ b/app/controllers/project/project_support_evidence_controller.rb
@@ -1,24 +1,32 @@
 class Project::ProjectSupportEvidenceController < ApplicationController
-
   include ProjectContext
-
-  def project_support_evidence
-
-  end
 
   def put
 
-    @project.evidence_description.push(params[:project][:evidence_description]) if params[:project][:evidence_description].present?
-    @project.evidence_of_support_files.attach(params[:project][:evidence_of_support_files]) if params[:project][:evidence_of_support_files].present?
-    @project.save
+    logger.debug "Adding evidence of support for project ID: #{@project.id}"
 
-    redirect_to three_to_ten_k_project_project_support_evidence_path(@project.id)
+    @project.validate_evidence_of_support = true
+
+    @project.update(project_params)
+
+    if @project.valid?
+
+      logger.debug "Finished adding evidence of support for project ID: #{@project.id}"
+
+      redirect_to three_to_ten_k_project_project_support_evidence_path
+
+    else
+
+      logger.debug "Validation failed when adding evidence of support for project ID: #{@project.id}"
+
+      render :show
+
+    end
 
   end
 
   private
-
   def project_params
-    params.require(:project).permit(:evidence_description, :evidence_of_support_files[])
+    params.require(:project).permit(evidence_of_support_attributes: [:description, :evidence_of_support_files])
   end
 end

--- a/app/models/evidence_of_support.rb
+++ b/app/models/evidence_of_support.rb
@@ -1,0 +1,30 @@
+class EvidenceOfSupport < ApplicationRecord
+  include GenericValidator
+
+  # This overrides Rails attempting to pluralise the model name
+  self.table_name = "evidence_of_support"
+
+  self.implicit_order_column = "created_at"
+
+  belongs_to :project
+  has_many_attached :evidence_of_support_files
+
+  validates :description, presence: true
+
+  validate do
+
+    validate_file_attached(
+        :evidence_of_support_files,
+        "Add an evidence of support file"
+    )
+
+    validate_length(
+        :description,
+        50,
+        "Description of your evidence of support must be 50 words or fewer"
+    )
+
+  end
+
+end
+

--- a/app/models/evidence_of_support.rb
+++ b/app/models/evidence_of_support.rb
@@ -7,7 +7,7 @@ class EvidenceOfSupport < ApplicationRecord
   self.implicit_order_column = "created_at"
 
   belongs_to :project
-  has_many_attached :evidence_of_support_files
+  has_one_attached :evidence_of_support_files
 
   validates :description, presence: true
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,20 +3,29 @@ class Project < ApplicationRecord
     self.implicit_order_column = "created_at"
 
     belongs_to :user
+
     has_one :organisation, through: :user
+
     has_many :released_forms
     has_many :cash_contributions
     has_many :non_cash_contributions
     has_many :project_costs
     has_many :volunteers
-    has_many_attached :evidence_of_support_files
+    has_many :evidence_of_support
+
     has_one_attached :capital_work_file
-    accepts_nested_attributes_for :cash_contributions, :non_cash_contributions, :project_costs, :volunteers
+
+    accepts_nested_attributes_for :cash_contributions,
+                                  :non_cash_contributions,
+                                  :project_costs,
+                                  :volunteers,
+                                  :evidence_of_support
 
     validates_associated :cash_contributions, if: :validate_cash_contributions?
     validates_associated :non_cash_contributions, if: :validate_non_cash_contributions?
     validates_associated :project_costs, if: :validate_project_costs?
     validates_associated :volunteers, if: :validate_volunteers?
+    validates_associated :evidence_of_support, if: :validate_evidence_of_support?
 
     attr_accessor :validate_title
     attr_accessor :validate_start_and_end_dates
@@ -37,6 +46,7 @@ class Project < ApplicationRecord
     attr_accessor :validate_project_costs
     attr_accessor :validate_cash_contributions
     attr_accessor :validate_non_cash_contributions
+    attr_accessor :validate_evidence_of_support
     attr_accessor :validate_volunteers
     attr_accessor :validate_cash_contributions_question
     attr_accessor :validate_non_cash_contributions_question
@@ -259,6 +269,10 @@ class Project < ApplicationRecord
 
     def validate_non_cash_contributions?
         validate_non_cash_contributions == true
+    end
+
+    def validate_evidence_of_support?
+        validate_evidence_of_support == true
     end
 
     def validate_volunteers?

--- a/app/views/project/project_support_evidence/show.html.erb
+++ b/app/views/project/project_support_evidence/show.html.erb
@@ -28,8 +28,8 @@
                 <%= eos.description %>
             </td>
             <td class="govuk-table__cell">
-                <%= link_to(eos.evidence_of_support_files.blobs.first.filename,
-                            rails_blob_path(eos.evidence_of_support_files.blobs.first, disposition: "attachment"))
+                <%= link_to(eos.evidence_of_support_files.blob.filename,
+                            rails_blob_path(eos.evidence_of_support_files.blob, disposition: "attachment"))
                 %>
             </td>
           </tr>

--- a/app/views/project/project_support_evidence/show.html.erb
+++ b/app/views/project/project_support_evidence/show.html.erb
@@ -1,4 +1,6 @@
-<% content_for :page_title, "Evidence of support" %>
+<% content_for :page_title, @project.errors.any? ? "Error: Evidence of support" : "Evidence of support" %>
+
+<div id="summary-errors"></div>
 
 <span class="govuk-caption-xl">Support for your project</span>
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">Evidence of support</h1>
@@ -9,7 +11,7 @@
     <h2 class="govuk-heading-m">Your evidence of support</h2>
   </header>
   <div class="nlhf-summary__body">
-    <% unless @project.evidence_description.any? %>
+    <% unless @project.evidence_of_support.first&.id.present? %>
         <h3 class="govuk-heading-m govuk-!-margin-bottom-0">You have not added any evidence</h3>
     <% else %>
       <table class="govuk-table govuk-!-margin-bottom-0">
@@ -20,13 +22,15 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-            <%= @project.evidence_description.zip @project.evidence_of_support_files.each do |description, file|  %>
+            <% @project.evidence_of_support.filter { |eos| eos.id.present? }.each do |eos|  %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-                <%= description %>
+                <%= eos.description %>
             </td>
             <td class="govuk-table__cell">
-                <%=link_to(file.blob.filename, rails_blob_path(file, disposition: "attachment")) %>
+                <%= link_to(eos.evidence_of_support_files.blobs.first.filename,
+                            rails_blob_path(eos.evidence_of_support_files.blobs.first, disposition: "attachment"))
+                %>
             </td>
           </tr>
           <% end %>
@@ -38,6 +42,8 @@
 
 <%= form_with model: @project, url: three_to_ten_k_project_project_support_evidence_path, method: :put, remote: true do |f| %>
 
+  <% f.fields_for :evidence_of_support, @project.evidence_of_support.build do |e| %>
+
   <div class="nlhf-add-item govuk-!-margin-bottom-9">
     
     <header class="nlhf-add-item__header">
@@ -48,12 +54,15 @@
 
       <div class="nlhf-add-item__row">
         <div class="govuk-character-count" data-module="govuk-character-count" data-maxwords="50">
-          <div class="govuk-form-group">
+          <div class="govuk-form-group" id="evidence-description-form-group">
+
+            <div id="evidence-description-errors"></div>
+
             <label class="govuk-label" for="evidence-description">
               Describe the evidence you are providing
             </label>
-            <%= f.text_area :evidence_description, value: "", id: 'evidence-description', class: 'govuk-textarea govuk-js-character-count', required: "true", rows: 5 %>
-            <span id="evidence-description-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
+            <%= e.text_area :description, value: "", class: 'govuk-textarea govuk-js-character-count', rows: 5 %>
+            <span id="project_evidence_of_support_attributes_0_description-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
               You have 50 words remaining
             </span>
           </div>
@@ -62,11 +71,11 @@
       <!-- / nlhf-add-item__row -->
 
       <div class="nlhf-add-item__row">
-        <div class="govuk-form-group">
+        <div class="govuk-form-group" id="file-upload-group">
           <label class="govuk-label" for="evidence-upload">
             Upload a file
           </label>
-          <%= f.file_field :evidence_of_support_files, multiple: false, direct_upload: true, id: 'evidence-upload', required: 'true' %>
+          <%= e.file_field :evidence_of_support_files, multiple: false, direct_upload: true, class: 'govuk-file-upload' %>
         </div>
       </div>
       <!-- / nlhf-add-item__row -->
@@ -80,6 +89,7 @@
 
     </div>
   </div>
+    <% end %>
 <% end %>
 
 <details class="govuk-details" data-module="govuk-details">

--- a/app/views/project/project_support_evidence/show.js.erb
+++ b/app/views/project/project_support_evidence/show.js.erb
@@ -1,0 +1,161 @@
+<% if @project.errors.any? %>
+
+document.title = "Error: Evidence of support";
+
+addSummaryErrors("evidence_of_support");
+
+addFormGroupErrors(
+    "evidence_of_support.description",
+    "evidence-description-form-group",
+    "project_evidence_of_support_attributes_0_description",
+    "evidence-description-errors"
+);
+
+addErrorToFileField();
+
+<% end %>
+
+function addSummaryErrors(modelName) {
+
+    var summaryErrorsElement = document.getElementById("summary-errors");
+
+    if (summaryErrorsElement.classList.contains("govuk-error-summary") === false)
+        summaryErrorsElement.classList.add("govuk-error-summary");
+
+    summaryErrorsElement.setAttribute("aria-labelledby", "error-summary-title");
+    summaryErrorsElement.setAttribute("role", "alert");
+    summaryErrorsElement.setAttribute("tabindex", "-1");
+    summaryErrorsElement.setAttribute("data-module", "govuk-error-summary");
+
+    if (summaryErrorsElement.innerHTML.includes("h2") === false) {
+        var summaryErrorsHeading = document.createElement("h2");
+        summaryErrorsHeading.classList.add("govuk-error-summary__title");
+        summaryErrorsHeading.setAttribute("id", "error-summary-title");
+        summaryErrorsHeading.innerText = "There is a problem";
+        summaryErrorsElement.appendChild(summaryErrorsHeading);
+    }
+
+    if (summaryErrorsElement.innerHTML.includes("div") === false) {
+        var summaryErrorsBodyElement = document.createElement("div");
+        summaryErrorsBodyElement.setAttribute("id", "summary-errors-body");
+        summaryErrorsBodyElement.classList.add("govuk-error-summary__body");
+        summaryErrorsElement.appendChild(summaryErrorsBodyElement);
+    } else {
+        var summaryErrorsBodyElement = document.getElementById("summary-errors-body");
+    }
+
+    if (summaryErrorsElement.innerHTML.includes("ul") === false) {
+        var summaryErrorsList = document.createElement("ul");
+        summaryErrorsList.setAttribute("id", "summary-errors-list");
+        summaryErrorsList.classList.add("govuk-list")
+        summaryErrorsList.classList.add("govuk-error-summary__list");
+        summaryErrorsBodyElement.appendChild(summaryErrorsList);
+    } else {
+        var summaryErrorsList = document.getElementById("summary-errors-list");
+        summaryErrorsList.innerHTML = "";
+    }
+
+
+    <% @project.errors.each do |attr, msg| %>
+
+    if (summaryErrorsElement.innerHTML.includes("<%= msg %>") === false
+        && ("<%= attr.to_s %>" !== modelName)) {
+
+        var listItemElement = document.createElement("li");
+        var linkElement = document.createElement("a");
+
+        linkElement.setAttribute("data-turbolinks", "false");
+
+        var fieldName = "<%= attr.to_s %>".split(".")[1];
+
+        linkElement.setAttribute("href", "#project_" + modelName + "_attributes_0_" + fieldName);
+
+        linkElement.innerText = "<%= msg %>";
+
+        listItemElement.appendChild(linkElement)
+        summaryErrorsList.appendChild(listItemElement);
+
+    }
+
+    <% end %>
+
+}
+
+function addFormGroupErrors(model_field, form_group, input_element, errors_element) {
+
+    var descriptionFormGroupElement = document.getElementById(form_group);
+    descriptionFormGroupElement.classList.add("govuk-form-group--error");
+
+    var inputElement = document.getElementById(input_element);
+
+    var descriptionFormGroupErrorsElement = document.getElementById(errors_element);
+    descriptionFormGroupErrorsElement.innerHTML = "";
+
+    var errorKeys = []
+
+    <% @project.errors.each do |attr, msg| %>
+
+    errorKeys.push("<%= attr.to_s %>");
+
+    if (model_field == "<%= attr.to_s %>") {
+
+        if (descriptionFormGroupErrorsElement.innerHTML.includes("<%== escape_javascript(msg) %>") === false) {
+
+            inputElement.classList.add("govuk-textarea--error");
+
+            var spanElement = document.createElement("span");
+            spanElement.setAttribute("id", "project[<%= attr %>]-error");
+            spanElement.classList.add("govuk-error-message");
+            spanElement.innerHTML = "<span class='govuk-visually-hidden'>Error: </span><%= msg %>";
+
+            descriptionFormGroupErrorsElement.appendChild(spanElement);
+
+        }
+
+    }
+
+    <% end %>
+
+    if (errorKeys.includes(model_field) === false) {
+
+        descriptionFormGroupElement.classList.remove("govuk-form-group--error");
+        inputElement.classList.remove("govuk-textarea--error");
+
+    }
+
+}
+
+<%# TODO: Refactor this function so that it is reusable %>
+function addErrorToFileField() {
+
+    var fileUploadGroup = document.getElementById("file-upload-group");
+    var fileField = document.getElementById("project_evidence_of_support_attributes_0_evidence_of_support_files");
+
+    <% if @project.errors.key?("evidence_of_support.evidence_of_support_files") %>
+
+    var fileErrorMessage = "<%= escape_javascript(@project.errors["evidence_of_support.evidence_of_support_files"][0]) %>";
+
+    if (fileUploadGroup.innerHTML.includes(fileErrorMessage) === false) {
+
+        var spanElement = document.createElement("span");
+        spanElement.setAttribute("id", "evidence_of_support_files-error");
+        spanElement.classList.add("govuk-error-message");
+        spanElement.innerHTML = "<span class='govuk-visually-hidden'>Error: </span>" + fileErrorMessage;
+
+        fileField.classList.add("govuk-file-upload--error");
+        fileField.setAttribute("aria-describedby", "evidence_of_support_files-error");
+
+        fileUploadGroup.prepend(spanElement);
+
+    }
+
+    <% else %>
+
+    fileUploadGroup.removeChild(document.getElementById("evidence_of_support_files-error"));
+
+    fileField.classList.remove("govuk-file-upload--error");
+    fileField.removeAttribute("aria-describedby");
+
+    <% end %>
+
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,3 +150,7 @@ en-GB:
               blank: "Enter a description of your project volunteer"
             hours:
               not_a_number: "Hours must be a number, like 5"
+        evidence_of_support:
+          attributes:
+            description:
+              blank: "Enter a description of your evidence of support"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,8 +115,11 @@ Rails.application.routes.draw do
       get ':project_id/non-cash-contributions', to: 'project_non_cash_contributions#show', as: :non_cash_contributions_get
       put ':project_id/non-cash-contributions', to: 'project_non_cash_contributions#update', as: :non_cash_contributions_put
 
-      get ':project_id/volunteers' => 'project_volunteers#show', as: :volunteers
-      put ':project_id/volunteers' => 'project_volunteers#put'
+      get ':project_id/volunteers', to: 'project_volunteers#show', as: :volunteers
+      put ':project_id/volunteers', to: 'project_volunteers#put'
+
+      get ':project_id/evidence-of-support', to: 'project_support_evidence#show', as: :project_support_evidence
+      put ':project_id/evidence-of-support', to: 'project_support_evidence#put'
 
       get ':project_id/check-your-answers',
           to: 'project_check_answers#show', as: :check_answers_get
@@ -140,8 +143,6 @@ Rails.application.routes.draw do
       get 'location' => 'project_location#project_location'
 
       post 'submit-application' => 'show_declaration#submit_application'
-      get ':project_id/support-evidence' => 'project_support_evidence#project_support_evidence', as: :project_support_evidence
-      put ':project_id/support-evidence' => 'project_support_evidence#put'
 
     end
   end

--- a/db/migrate/20200122094326_add_evidence_of_support.rb
+++ b/db/migrate/20200122094326_add_evidence_of_support.rb
@@ -1,0 +1,12 @@
+class AddEvidenceOfSupport < ActiveRecord::Migration[6.0]
+  def change
+
+    create_table :evidence_of_support, id: :uuid do |t|
+      t.string "description"
+      t.timestamps
+    end
+
+    remove_column :projects, :evidence_description
+
+  end
+end

--- a/db/migrate/20200122094550_add_project_ref_to_evidence_of_support.rb
+++ b/db/migrate/20200122094550_add_project_ref_to_evidence_of_support.rb
@@ -1,0 +1,5 @@
+class AddProjectRefToEvidenceOfSupport < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :evidence_of_support, :project, type: :uuid, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_20_111236) do
+ActiveRecord::Schema.define(version: 2020_01_22_094550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -46,6 +46,14 @@ ActiveRecord::Schema.define(version: 2020_01_20_111236) do
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "project_id", null: false
     t.index ["project_id"], name: "index_cash_contributions_on_project_id"
+  end
+
+  create_table "evidence_of_support", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.uuid "project_id", null: false
+    t.index ["project_id"], name: "index_evidence_of_support_on_project_id"
   end
 
   create_table "legal_signatories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -100,7 +108,6 @@ ActiveRecord::Schema.define(version: 2020_01_20_111236) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id", null: false
-    t.string "evidence_description", default: [], array: true
     t.date "start_date"
     t.date "end_date"
     t.text "description"
@@ -185,6 +192,7 @@ ActiveRecord::Schema.define(version: 2020_01_20_111236) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "cash_contributions", "projects"
+  add_foreign_key "evidence_of_support", "projects"
   add_foreign_key "non_cash_contributions", "projects"
   add_foreign_key "project_costs", "projects"
   add_foreign_key "projects", "users"


### PR DESCRIPTION
This pull request splits supporting evidence into it's own model and adds validation to the relevant page.

Note that it's the same validation used on similar pages, I'll revisit DRY-ing this and making it reusable and slightly more robust once the entire journey is wired up and in place.