### PR TITLE
Updated initial organisation validation

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -10,21 +10,22 @@ class HomeController < ApplicationController
 
     if current_user.organisation
 
-      logger.info "Existing organisation #{current_user.organisation.id} found for #{current_user.id.to_s}"
+      logger.info "Existing organisation #{current_user.organisation.id} found for #{current_user.id}"
 
-      @start_now_link_value = three_to_ten_k_project_create_path
+      @start_now_link_value = complete_organisation_details? ? three_to_ten_k_project_create_path :
+                                  organisation_type_path(current_user.organisation.id)
 
     else
 
-      logger.info "No existing organisation found for user ID: #{current_user.id.to_s}"
+      logger.info "No existing organisation found for user ID: #{current_user.id}"
 
-      logger.debug "Creating organisation for user ID: #{current_user.id.to_s}"
+      logger.debug "Creating organisation for user ID: #{current_user.id}"
 
       @organisation = Organisation.create
 
-      logger.debug "Finished creating organisation #{@organisation.id} for user ID: #{current_user.id.to_s}"
+      logger.debug "Finished creating organisation #{@organisation.id} for user ID: #{current_user.id}"
 
-      logger.debug "Updating user ID: #{current_user.id.to_s} with link to organisation #{@organisation.id}"
+      logger.debug "Updating user ID: #{current_user.id} with link to organisation #{@organisation.id}"
 
       @user = User.update(current_user.id, organisation_id: @organisation.id)
 
@@ -33,6 +34,24 @@ class HomeController < ApplicationController
       @start_now_link_value = organisation_type_path(@organisation.id)
 
     end
+
+  end
+
+  private
+  # Checks for the presence of mandatory organisation parameters,
+  # returning false if any are not present and true if all are
+  # present
+  def complete_organisation_details?
+
+    return [
+        current_user.organisation.name.present?,
+        current_user.organisation.line1.present?,
+        current_user.organisation.townCity.present?,
+        current_user.organisation.county.present?,
+        current_user.organisation.postcode.present?,
+        current_user.organisation.org_type.present?,
+        current_user.organisation.legal_signatories.exists?
+    ].all?
 
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -43,7 +43,7 @@ class HomeController < ApplicationController
   # present
   def complete_organisation_details?
 
-    return [
+    [
         current_user.organisation.name.present?,
         current_user.organisation.line1.present?,
         current_user.organisation.townCity.present?,

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -10,7 +10,7 @@
 <p class="govuk-body">Apply for funding from the National Lottery Heritage fund for your heritage project</p>
 
 <a href="<%= @start_now_link_value %>" role="button" draggable="false" class="govuk-button govuk-button--start"
-   data-module="govuk-button" aria-label="Start now">
+   data-module="govuk-button" aria-label="Start now" data-prevent-double-click="true" data-turbolinks="false">
   Start Now
   <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40"
        role="presentation" focusable="false">

--- a/app/views/project/new_project/new_project.html.erb
+++ b/app/views/project/new_project/new_project.html.erb
@@ -1,8 +1,0 @@
-<h1>Project::NewProject#new_project</h1>
-<p>Find me in app/views/3-10k/project/new_project/new_project.html.erb</p>
-
-<%= form_tag(three_to_ten_k_project_temp_create_new_url, {method: :put}) do %>
-
-  <%= submit_tag "Create new project", {class:'govuk-button', role: 'button'} %>
-
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
         as: :assign_address_attributes
     # This route ensures that attempting to navigate back to the list of address results
     # redirects the user back to the search page
-    get 'address/results', to: 'about#show_postcode_lookup'
+    get 'address/results', to: 'address#show_postcode_lookup'
 
   end
 


### PR DESCRIPTION
This pull request extends the existing validation that takes place to determine whether or not a user should be directed to the organisation or project sections of the service. 

Previously, we were only checking to see whether a user had a related organisation, directing them to the project section if so or to the organisation section if not.

Now, we check to see whether the user has a related organisation and whether or not this organisation has the mandatory organisation attributes populated. If not, we direct the user to the organisation section of the service. If the user does not have an organisation, we still direct them into the organisation section of the service. If the user has an organisation and this organisation has the necessary mandatory attributes populated then we direct them to the project section of the service.

As well as this, this pull request fixes a bug where Turbolinks was causing a project to be created twice from the 'Start a project' page, and fixes a bug which was causing a 500 error due to a mis-named route.

Closes #167 