### PR TITLE
Implemented fix to nil-value bug on grant request page

### DIFF
--- a/app/controllers/project/project_grant_request_controller.rb
+++ b/app/controllers/project/project_grant_request_controller.rb
@@ -6,7 +6,7 @@ class Project::ProjectGrantRequestController < ApplicationController
     @total_project_cost = helpers.calculate_total(@project.project_costs)
     @total_cash_contributions = helpers.calculate_total(@project.cash_contributions)
 
-    @final_grant_amount = @total_project_cost - @total_cash_contributions
+    @final_grant_amount = @total_project_cost.to_i - @total_cash_contributions.to_i
 
   end
 

--- a/app/controllers/project/project_grant_request_controller.rb
+++ b/app/controllers/project/project_grant_request_controller.rb
@@ -3,10 +3,10 @@ class Project::ProjectGrantRequestController < ApplicationController
 
   def show
 
-    @total_project_cost = helpers.calculate_total(@project.project_costs)
-    @total_cash_contributions = helpers.calculate_total(@project.cash_contributions)
+    @total_project_cost = helpers.calculate_total(@project.project_costs).to_i
+    @total_cash_contributions = helpers.calculate_total(@project.cash_contributions).to_i
 
-    @final_grant_amount = @total_project_cost.to_i - @total_cash_contributions.to_i
+    @final_grant_amount = @total_project_cost - @total_cash_contributions
 
   end
 

--- a/app/views/project/project_grant_request/show.html.erb
+++ b/app/views/project/project_grant_request/show.html.erb
@@ -10,7 +10,13 @@
     <h2 class="govuk-heading-m">
       We have found a problem
     </h2>
-    <p class="govuk-body govuk-!-font-size-19">Your cash contributions are <%= "#{number_to_currency(@final_grant_amount.abs, strip_insignificant_zeros: true)}" %> more than the total cost of your project.</p>
+    <p class="govuk-body govuk-!-font-size-19">
+      <%= (@final_grant_amount.to_i == 0) ?
+              "You have not added any cash contributions or project costs"
+              : "Your cash contributions are #{number_to_currency(@final_grant_amount.abs,
+                                                                  strip_insignificant_zeros: true)} more than the total cost of your project"
+      %>
+    </p>
     <p class="govuk-body govuk-!-font-size-19">Please review your project costs and cash contributions.</p>
   </div>
 <% else %>


### PR DESCRIPTION
This commit fixes a bug which could occur on the 'Your Grant Request' page if a user had navigated to this page without setting any project costs or cash contributions.

Previously, the `@final_grant_amount` instance variable would have a value of nil, which would cause an error when the view attempted to use this variable.

Setting .to_i on the values inside the `@final_grant_amount` calculation implicitly converts them to 0 if they are nil.

As well, this commit adds an additional message to the 'Your grant request' page in case a `@final_grant_amount` of 0 is present.