### PR TITLE
Added running of Salesforce job to declaration controller

### DIFF
--- a/app/controllers/project/project_declaration_controller.rb
+++ b/app/controllers/project/project_declaration_controller.rb
@@ -13,6 +13,8 @@ class Project::ProjectDeclarationController < ApplicationController
 
       logger.debug "Finished updating declaration confirmation for project ID: #{@project.id}"
 
+      ApplicationToSalesforceJob.perform_later(@project)
+
       redirect_to three_to_ten_k_project_application_submitted_get_path
 
     else

--- a/app/controllers/project/project_declaration_controller.rb
+++ b/app/controllers/project/project_declaration_controller.rb
@@ -13,6 +13,8 @@ class Project::ProjectDeclarationController < ApplicationController
 
       logger.debug "Finished updating declaration confirmation for project ID: #{@project.id}"
 
+      logger.info "Triggering Salesforce job for project ID: #{@project.id}"
+
       ApplicationToSalesforceJob.perform_later(@project)
 
       redirect_to three_to_ten_k_project_application_submitted_get_path


### PR DESCRIPTION
This pull request adds functionality to run the Salesforce application submission job if a user has confirmed that they have read the declaration.