### PR TITLE
Made cash contributions secured value display dynamically

### DIFF
--- a/app/views/project/project_cash_contribution/show.html.erb
+++ b/app/views/project/project_cash_contribution/show.html.erb
@@ -24,7 +24,7 @@
         </tr>
         </thead>
         <tbody class="govuk-table__body">
-        <% @project.cash_contributions.filter { |cc| cc.id.present? }.each_with_index do |cc, index| %>
+        <% @project.cash_contributions.filter { |cc| cc.id.present? }.each do |cc| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell nlhf-table__cell govuk-!-width-one-half nlhf-table__cell--text">
               <%= cc.description %>

--- a/app/views/project/project_cash_contribution/show.html.erb
+++ b/app/views/project/project_cash_contribution/show.html.erb
@@ -24,17 +24,16 @@
         </tr>
         </thead>
         <tbody class="govuk-table__body">
-        <% @project.cash_contributions.filter { |cc| cc.description.present? }.each_with_index do |cc, index| %>
+        <% @project.cash_contributions.filter { |cc| cc.id.present? }.each_with_index do |cc, index| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell nlhf-table__cell govuk-!-width-one-half nlhf-table__cell--text">
               <%= cc.description %>
             </td>
             <td class="govuk-table__cell">
-              <%# TODO: Add human friendly value of the choosen radio box "supports" %>
-              Value here
+              <%= cc.secured&.gsub('x_', '').humanize.gsub('Yes ', 'Yes, ') %>
               <% if cc.cash_contribution_evidence_files.present? %>
                 <div class="nlhf-!-break-word govuk-!-font-size-16">
-                  <%= link_to("Evidence attached", rails_blob_path(cc.cash_contribution_evidence_files.first, disposition: "attachment"), title: "Click to view file: #{cc.cash_contribution_evidence_files.blobs.first.filename}") %>
+                  <%= link_to("Evidence attached", rails_blob_path(cc.cash_contribution_evidence_files, disposition: "attachment"), title: "Click to view file: #{cc.cash_contribution_evidence_files.filename}") %>
                 </div>
               <% end %>
             </td>


### PR DESCRIPTION
Previously we weren't displaying the actual `:secured` value for cash contributions in the table on this page. This pull request addresses this - removing the `x_` from the value for 'Not sure', humanising each value and then replacing `Yes ` with `Yes, ` for readability.

As well, this fixes a bug where cash contribution calculations included 'hidden' fields which weren't being displayed in the table because they did not have descriptions.

The `link_to` line was causing 500 errors, which has been fixed also.