### PR TITLE
Added contacts details to Salesforce payload

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -312,7 +312,7 @@ class Project < ApplicationRecord
                     json.endDate self.end_date
                 end
                 json.set!('mainContactName', self.user.name)
-                json.set!('mainContactDateOfBirth', self.user.date_of_birth)
+                json.set!('mainContactDateOfBirth', self.user.date_of_birth.to_s)
                 json.set!('mainContactEmail', self.user.email)
                 json.set!('mainContactPhone', self.user.phone_number)
                 json.mainContactAddress do

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -311,15 +311,17 @@ class Project < ApplicationRecord
                     json.startDate self.start_date
                     json.endDate self.end_date
                 end
-                #TODO: Replace this dummy data with real data
-                json.set!('mainContactName', "Jane Doe")
-                json.set!('mainContactDateOfBirth', "1975-10-12")
-                json.set!('mainContactEmail', "test@example.net")
+                json.set!('mainContactName', self.user.name)
+                json.set!('mainContactDateOfBirth', self.user.date_of_birth)
+                json.set!('mainContactEmail', self.user.email)
+                json.set!('mainContactPhone', self.user.phone_number)
                 json.mainContactAddress do
-                    json.line1 "Buckingham Palace"
-                    json.line2 "Westminster"
-                    json.townCity "London"
-                    json.postcode "SW1A 1AA"
+                    json.line1 self.user.line1
+                    json.line2 self.user.line2
+                    json.line3 self.user.line3
+                    json.townCity self.user.townCity
+                    json.county self.user.county
+                    json.postcode self.user.postcode
                 end
                 json.projectAddress do
                     json.line1 self.line1

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -312,7 +312,7 @@ class Project < ApplicationRecord
                     json.endDate self.end_date
                 end
                 json.set!('mainContactName', self.user.name)
-                json.set!('mainContactDateOfBirth', self.user.date_of_birth.to_s)
+                json.set!('mainContactDateOfBirth', self.user.date_of_birth)
                 json.set!('mainContactEmail', self.user.email)
                 json.set!('mainContactPhone', self.user.phone_number)
                 json.mainContactAddress do

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,6 +4,14 @@ one:
   id: 1
   email: test@example.com
   encrypted_password: <%= User.new.send(:password_digest, '123456') %>
+  name: "Joe O'Bloggs"
+  phone_number: "07700900000"
+  date_of_birth: "1980-01-01"
+  line1: "10 Downing Street"
+  line2: "Westminster"
+  townCity: "London"
+  county: "Greater London"
+  postcode: "SW1A 2AA"
   organisation_id: 'ca326b0a-89ba-44b2-8500-eee5e8ce611f'
 
 two:

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -8,6 +8,16 @@ class ProjectTest < ActiveSupport::TestCase
      assert_equal  '2c660111-ab15-4221-98e0-cf0e02748a9b', @project_salesforce_json_obj['meta']['applicationId']
      assert_equal 'test@example.com', @project_salesforce_json_obj['meta']['username']
 
+     # Assert mainContact parameters
+     assert_equal "Joe O'Bloggs", @project_salesforce_json_obj['application']['mainContactName']
+     assert_equal "07700900000", @project_salesforce_json_obj['application']['mainContactPhone']
+     assert_equal "test@example.com", @project_salesforce_json_obj['application']['mainContactEmail']
+     assert_equal "10 Downing Street", @project_salesforce_json_obj['application']['mainContactAddress']['line1']
+     assert_equal "Westminster", @project_salesforce_json_obj['application']['mainContactAddress']['line2']
+     assert_equal "London", @project_salesforce_json_obj['application']['mainContactAddress']['townCity']
+     assert_equal "Greater London", @project_salesforce_json_obj['application']['mainContactAddress']['county']
+     assert_equal "SW1A 2AA", @project_salesforce_json_obj['application']['mainContactAddress']['postcode']
+
      # Assert organisation parameters
      assert_equal 'test organisation', @project_salesforce_json_obj['application']['organisationName']
      assert_equal 'registered-charity', @project_salesforce_json_obj['application']['organisationType']


### PR DESCRIPTION
This pull request adds functionality to retrieve the correct data for the `mainContact` fields of the Salesforce payload, and also contains updates to the relevant test and fixtures.