### PR TITLE
adds in logic to view to validate grant request

### DIFF
--- a/app/controllers/project/project_grant_request_controller.rb
+++ b/app/controllers/project/project_grant_request_controller.rb
@@ -5,8 +5,11 @@ class Project::ProjectGrantRequestController < ApplicationController
 
     @total_project_cost = helpers.calculate_total(@project.project_costs).to_i
     @total_cash_contributions = helpers.calculate_total(@project.cash_contributions).to_i
-
     @final_grant_amount = @total_project_cost - @total_cash_contributions
+    @maximum_request_value = 10000.to_i
+    @costs_greater_than_contributions = @final_grant_amount.positive? ? true : false
+    @grant_request_less_than_funding_band = @final_grant_amount <= @maximum_request_value ? true : false
+    @grant_request_is_valid = @costs_greater_than_contributions && @grant_request_less_than_funding_band ? true : false
 
   end
 

--- a/app/controllers/project/project_grant_request_controller.rb
+++ b/app/controllers/project/project_grant_request_controller.rb
@@ -9,7 +9,7 @@ class Project::ProjectGrantRequestController < ApplicationController
     @maximum_request_value = 10000.to_i
     @costs_greater_than_contributions = @final_grant_amount.positive? 
     @grant_request_less_than_funding_band = @final_grant_amount <= @maximum_request_value 
-    @grant_request_is_valid = @costs_greater_than_contributions && @grant_request_less_than_funding_band ? true : false
+    @grant_request_is_valid = @costs_greater_than_contributions && @grant_request_less_than_funding_band
 
   end
 

--- a/app/controllers/project/project_grant_request_controller.rb
+++ b/app/controllers/project/project_grant_request_controller.rb
@@ -7,7 +7,7 @@ class Project::ProjectGrantRequestController < ApplicationController
     @total_cash_contributions = helpers.calculate_total(@project.cash_contributions).to_i
     @final_grant_amount = @total_project_cost - @total_cash_contributions
     @maximum_request_value = 10000.to_i
-    @costs_greater_than_contributions = @final_grant_amount.positive? ? true : false
+    @costs_greater_than_contributions = @final_grant_amount.positive? 
     @grant_request_less_than_funding_band = @final_grant_amount <= @maximum_request_value ? true : false
     @grant_request_is_valid = @costs_greater_than_contributions && @grant_request_less_than_funding_band ? true : false
 

--- a/app/controllers/project/project_grant_request_controller.rb
+++ b/app/controllers/project/project_grant_request_controller.rb
@@ -8,7 +8,7 @@ class Project::ProjectGrantRequestController < ApplicationController
     @final_grant_amount = @total_project_cost - @total_cash_contributions
     @maximum_request_value = 10000.to_i
     @costs_greater_than_contributions = @final_grant_amount.positive? 
-    @grant_request_less_than_funding_band = @final_grant_amount <= @maximum_request_value ? true : false
+    @grant_request_less_than_funding_band = @final_grant_amount <= @maximum_request_value 
     @grant_request_is_valid = @costs_greater_than_contributions && @grant_request_less_than_funding_band ? true : false
 
   end

--- a/app/views/project/project_grant_request/show.html.erb
+++ b/app/views/project/project_grant_request/show.html.erb
@@ -5,32 +5,36 @@
   Your grant request
 </h1>
 
-<%
-  $maximumRequestValue = 10000.to_i
-  $costsGreaterThanContributions = ((@final_grant_amount.to_i).positive? ? true : false)
-  $grantRequestLessThanFundingBand = ((@final_grant_amount.to_i)<= $maximumRequestValue ? true : false)
-  $grantRequestIsValid = ($costsGreaterThanContributions and $grantRequestLessThanFundingBand ? true : false)  
-%>
-
-<% unless $grantRequestIsValid %>
+<% unless @grant_request_is_valid %>
   <div class="nlhf-panel nlhf-alert nlhf-alert--error nlhf-alert--slim govuk-!-margin-bottom-8">
     <h2 class="govuk-heading-m">
       We have found a problem
     </h2>
 
-    <%# show this message if grant request is a negative number (not greater than the ammount being received in contributions)  %>
-    <% unless $costsGreaterThanContributions %>      
-      <p class="govuk-body govuk-!-font-size-19">
-        Your cash contributions are <%= "#{number_to_currency(@final_grant_amount.abs, strip_insignificant_zeros: true)}"  %>  more than the total cost of your project.
-      </p>
-    <% end %>
+    <p class="govuk-body govuk-font-size-19">
 
-    <%# show this message if grant request is higher than the maximum value for this funding level  %>
-    <% unless $grantRequestLessThanFundingBand %>      
-      <p class="govuk-body govuk-!-font-size-19">
-        Your grant request is higher than &pound;10,000 which the maximum allowable for this funding programme.
-      </p>
-    <% end %>
+      <%# Show this message if there are no project costs or cash contributions %>
+      <% if @final_grant_amount == 0 %>
+
+        You have not added any project costs or cash contributions.
+
+      <% else %>
+
+        <%# show this message if grant request is a negative number (not greater than the amount being received in contributions)  %>
+        <% unless @costs_greater_than_contributions %>
+          Your cash contributions are
+          <%= "#{number_to_currency(@final_grant_amount.abs, strip_insignificant_zeros: true)}"  %>
+          more than the total cost of your project.
+        <% end %>
+
+        <%# show this message if grant request is higher than the maximum value for this funding level  %>
+        <% unless @grant_request_less_than_funding_band %>
+          Your grant request is higher than &pound;10,000 which the maximum allowable for this funding programme.
+        <% end %>
+      <% end %>
+
+    </p>
+
     <p class="govuk-body govuk-!-font-size-19">
       Please review your project costs and cash contributions.
     </p>
@@ -131,7 +135,7 @@
 </div>
 <!-- /.nlhf-calculation-breakdown -->
 
-<% if $grantRequestIsValid %>
+<% if @grant_request_is_valid %>
 <p>
   <a href="<%= "#{three_to_ten_k_project_non_cash_contributions_get_url}" %>" role="button" draggable="false"
     class="govuk-button" data-module="govuk-button" aria-label="Continue button">

--- a/app/views/project/project_grant_request/show.html.erb
+++ b/app/views/project/project_grant_request/show.html.erb
@@ -5,19 +5,36 @@
   Your grant request
 </h1>
 
-<% unless (@final_grant_amount.to_i).positive? %>
+<%
+  $maximumRequestValue = 10000.to_i
+  $costsGreaterThanContributions = ((@final_grant_amount.to_i).positive? ? true : false)
+  $grantRequestLessThanFundingBand = ((@final_grant_amount.to_i)<= $maximumRequestValue ? true : false)
+  $grantRequestIsValid = (!$costsGreaterThanContributions and $grantRequestLessThanFundingBand ? true : false)  
+%>
+
+<% unless $grantRequestIsValid %>
+
   <div class="nlhf-panel nlhf-alert nlhf-alert--error nlhf-alert--slim govuk-!-margin-bottom-8">
     <h2 class="govuk-heading-m">
       We have found a problem
     </h2>
+
+    <%# show this message if grant request is a negative number (not greater than the ammount being received in contributions)  %>
+    <% unless $costsGreaterThanContributions %>      
+      <p class="govuk-body govuk-!-font-size-19">
+        Your cash contributions are <%= "#{number_to_currency(@final_grant_amount.abs, strip_insignificant_zeros: true)}"  %>  more than the total cost of your project.
+      </p>
+    <% end %>
+
+    <%# show this message if grant request is higher than the maximum value for this funding level  %>
+    <% unless $grantRequestLessThanFundingBand %>      
+      <p class="govuk-body govuk-!-font-size-19">
+        Your grant request is higher than &pound;10,000 which the maximum allowable for this funding programme.
+      </p>
+    <% end %>
     <p class="govuk-body govuk-!-font-size-19">
-      <%= (@final_grant_amount.to_i == 0) ?
-              "You have not added any cash contributions or project costs"
-              : "Your cash contributions are #{number_to_currency(@final_grant_amount.abs,
-                                                                  strip_insignificant_zeros: true)} more than the total cost of your project"
-      %>
+      Please review your project costs and cash contributions.
     </p>
-    <p class="govuk-body govuk-!-font-size-19">Please review your project costs and cash contributions.</p>
   </div>
 <% else %>
   <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-7">
@@ -115,9 +132,12 @@
 </div>
 <!-- /.nlhf-calculation-breakdown -->
 
-<% if (@final_grant_amount.to_i).positive? %>
+<% if $grantRequestIsValid %>
+<p>
   <a href="<%= "#{three_to_ten_k_project_non_cash_contributions_get_url}" %>" role="button" draggable="false"
     class="govuk-button" data-module="govuk-button" aria-label="Continue button">
     Save and continue
   </a>
+</p>
+
 <% end %>

--- a/app/views/project/project_grant_request/show.html.erb
+++ b/app/views/project/project_grant_request/show.html.erb
@@ -9,11 +9,10 @@
   $maximumRequestValue = 10000.to_i
   $costsGreaterThanContributions = ((@final_grant_amount.to_i).positive? ? true : false)
   $grantRequestLessThanFundingBand = ((@final_grant_amount.to_i)<= $maximumRequestValue ? true : false)
-  $grantRequestIsValid = (!$costsGreaterThanContributions and $grantRequestLessThanFundingBand ? true : false)  
+  $grantRequestIsValid = ($costsGreaterThanContributions and $grantRequestLessThanFundingBand ? true : false)  
 %>
 
 <% unless $grantRequestIsValid %>
-
   <div class="nlhf-panel nlhf-alert nlhf-alert--error nlhf-alert--slim govuk-!-margin-bottom-8">
     <h2 class="govuk-heading-m">
       We have found a problem


### PR DESCRIPTION
This is probably really noddy but does what we intend for the grant request page.

- Value greater than funding programme maximum will not let users continue and prompts to view costs and contributions
- Will not let users continue if their grant request is invalid due to cash contributions being higher than project costs.

@stuartmccoll or @gidsg - This will likely need refactoring but hopefully you can see how I've structured the content, mark-up depending on those scenarios.