### PR TITLE
add field check before populating legal signatory 2

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -405,7 +405,8 @@ class Project < ApplicationRecord
                     set_legal_signatory_fields.call(@ls_one)
                 end
                 @ls_two = self.organisation.legal_signatories.second
-                if @ls_two.present?
+                # TODO Only create legal signatory two record if populated
+                if @ls_two&.name.present?
                     json.authorisedSignatoryTwoDetails do
                         set_legal_signatory_fields.call(@ls_two)
                     end


### PR DESCRIPTION
Currently even if legal signatory 2 is not populated it creates a record with an ID on save. This extra check stops the child element being erroneously created in that case.