### PR TITLE
Added deletion of project volunteers

### DIFF
--- a/app/controllers/project/project_volunteers_controller.rb
+++ b/app/controllers/project/project_volunteers_controller.rb
@@ -33,6 +33,23 @@ class Project::ProjectVolunteersController < ApplicationController
 
   end
 
+  def delete
+
+    logger.debug "User has selected to delete volunteer cost ID: #{params[:volunteer_id]}" \
+                    " from project ID: #{@project.id}"
+
+    volunteer = Volunteer.find(params[:volunteer_id])
+
+    logger.debug "Deleting volunteer ID: #{volunteer.id}"
+
+    volunteer.destroy if volunteer.project_id == @project.id
+
+    logger.debug "Finished deleting volunteer ID: #{volunteer.id}"
+
+    redirect_to three_to_ten_k_project_volunteers_path
+
+  end
+
   private
   def project_params
     params.require(:project).permit(volunteers_attributes: [:description, :hours])

--- a/app/views/project/project_volunteers/show.html.erb
+++ b/app/views/project/project_volunteers/show.html.erb
@@ -53,6 +53,7 @@
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Description</th>
           <th scope="col" class="govuk-table__header govuk-table__header--numeric">Hours</th>
+          <th scope="col" class="govuk-table__header"></th>
         </tr>
         </thead>
 
@@ -62,6 +63,18 @@
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= v.description %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= v.hours %></td>
+            <td class="govuk-table__cell">
+            <%= form_with model: @project,
+                          url: three_to_ten_k_project_volunteer_delete_path(volunteer_id: v.id),
+                          method: :delete,
+                          local: true do |f| %>
+
+              <%= f.submit "Delete", class: "govuk-button govuk-button--warning",
+                           "data-module" => "govuk-button", "data-turbolinks" => "false",
+                           "aria-label" => "Delete button"
+              %>
+            <% end %>
+            </td>
           </tr>
         <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,6 +158,8 @@ Rails.application.routes.draw do
       get ':project_id/volunteers', to: 'project_volunteers#show', as: :volunteers
       put ':project_id/volunteers', to: 'project_volunteers#put'
 
+      delete ':project_id/volunteers/:volunteer_id', to: 'project_volunteers#delete', as: :volunteer_delete
+
       get ':project_id/evidence-of-support', to: 'project_support_evidence#show', as: :project_support_evidence
       put ':project_id/evidence-of-support', to: 'project_support_evidence#put'
 


### PR DESCRIPTION
This pull request implements the functionality to delete volunteers that have been added to a project. This follows the same pattern used in #182 for the deletion of project costs.