### PR TITLE
Added delete functionality to non-cash contributions

### DIFF
--- a/app/controllers/project/project_non_cash_contributions_controller.rb
+++ b/app/controllers/project/project_non_cash_contributions_controller.rb
@@ -67,6 +67,23 @@ class Project::ProjectNonCashContributionsController < ApplicationController
 
   end
 
+  def delete
+
+    logger.debug "User has selected to delete non-cash contribution ID: #{params[:non_cash_contribution_id]}" \
+                    " from project ID: #{@project.id}"
+
+    non_cash_contribution = NonCashContribution.find(params[:non_cash_contribution_id])
+
+    logger.debug "Deleting non-cash contribution ID: #{non_cash_contribution.id}"
+
+    non_cash_contribution.destroy if non_cash_contribution.project_id == @project.id
+
+    logger.debug "Finished deleting non-cash contribution ID: #{non_cash_contribution.id}"
+
+    redirect_to three_to_ten_k_project_non_cash_contributions_get_path
+
+  end
+
   private
   def question_params
     if !params[:project].present?

--- a/app/views/project/project_non_cash_contributions/show.html.erb
+++ b/app/views/project/project_non_cash_contributions/show.html.erb
@@ -51,6 +51,7 @@
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">Description</th>
             <th scope="col" class="govuk-table__header govuk-table__header--numeric">Value</th>
+            <th scope="col" class="govuk-table__header"></th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
@@ -61,6 +62,18 @@
             </td>
             <td class="govuk-table__cell govuk-table__cell--numeric">
               <%= "#{number_to_currency(ncc.amount, strip_insignificant_zeros: true)}" if ncc.amount.present? %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= form_with model: @project,
+                            url: three_to_ten_k_project_non_cash_contribution_delete_path(non_cash_contribution_id: ncc.id),
+                            method: :delete,
+                            local: true do |f| %>
+
+                <%= f.submit "Delete", class: "govuk-button govuk-button--warning",
+                             "data-module" => "govuk-button", "data-turbolinks" => "false",
+                             "aria-label" => "Delete button"
+                %>
+              <% end %>
             </td>
           </tr>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,6 +155,10 @@ Rails.application.routes.draw do
       get ':project_id/non-cash-contributions', to: 'project_non_cash_contributions#show', as: :non_cash_contributions_get
       put ':project_id/non-cash-contributions', to: 'project_non_cash_contributions#update', as: :non_cash_contributions_put
 
+      delete ':project_id/non-cash-contributions/:non_cash_contribution_id',
+             to: 'project_non_cash_contributions#delete',
+             as: :non_cash_contribution_delete
+
       get ':project_id/volunteers', to: 'project_volunteers#show', as: :volunteers
       put ':project_id/volunteers', to: 'project_volunteers#put'
 


### PR DESCRIPTION
This pull request implements the functionality to delete non-cash contributions that have been added to a project. This follows the same pattern used in #182 for the deletion of project costs.