### PR TITLE
Added delete functionality to cash contributions

### DIFF
--- a/app/controllers/project/project_cash_contribution_controller.rb
+++ b/app/controllers/project/project_cash_contribution_controller.rb
@@ -62,6 +62,22 @@ class Project::ProjectCashContributionController < ApplicationController
 
   end
 
+  def delete
+
+    logger.debug "User has selected to delete cash contribution ID: #{params[:cash_contribution_id]} from project ID: #{@project.id}"
+
+    cash_contribution = CashContribution.find(params[:cash_contribution_id])
+
+    logger.debug "Deleting cash contribution ID: #{cash_contribution.id}"
+
+    cash_contribution.destroy if cash_contribution.project_id == @project.id
+
+    logger.debug "Finished deleting cash contribution ID: #{cash_contribution.id}"
+
+    redirect_to three_to_ten_k_project_project_cash_contribution_path
+
+  end
+
   private
   def question_params
     if !params[:project].present?

--- a/app/views/project/project_cash_contribution/show.html.erb
+++ b/app/views/project/project_cash_contribution/show.html.erb
@@ -21,6 +21,7 @@
           <th scope="col" class="govuk-table__header govuk-!-width-one-half">Description</th>
           <th scope="col" class="govuk-table__header">Secured</th>
           <th scope="col" class="govuk-table__header govuk-table__header--numeric">Value</th>
+          <th scope="col" class="govuk-table__header"></th>
         </tr>
         </thead>
         <tbody class="govuk-table__body">
@@ -40,6 +41,19 @@
             </td>
             <td class="govuk-table__cell govuk-table__cell--numeric">
               <%= number_to_currency(cc.amount, strip_insignificant_zeros: true) if cc.amount.present? %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= form_with model: @project,
+                            url: three_to_ten_k_project_cash_contribution_delete_path(cash_contribution_id: cc.id),
+                            method: :delete,
+                            local: true do |f| %>
+
+                <%= f.submit "Delete", class: "govuk-button govuk-button--warning",
+                             "data-module" => "govuk-button", "data-turbolinks" => "false",
+                             "aria-label" => "Delete button"
+                %>
+
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,10 @@ Rails.application.routes.draw do
           as: :project_cash_contribution
       put ':project_id/cash-contributions', to: 'project_cash_contribution#put'
 
+      delete ':project_id/cash-contributions/:cash_contribution_id',
+             to: 'project_cash_contribution#delete',
+             as: :cash_contribution_delete
+
       get ':project_id/your-grant-request' => 'project_grant_request#show', as: :grant_request_get
 
       get ':project_id/are-you-getting-non-cash-contributions',


### PR DESCRIPTION
This pull request implements the functionality to delete cash contributions that have been added to a project. This follows the same pattern used in #182 for the deletion of project costs.

This method will also remove the related attachment from the `active_storage_attachments` and `active_storage_blobs` tables.