### PR TITLE
Added delete functionality to evidence of support

### DIFF
--- a/app/controllers/project/project_support_evidence_controller.rb
+++ b/app/controllers/project/project_support_evidence_controller.rb
@@ -25,6 +25,22 @@ class Project::ProjectSupportEvidenceController < ApplicationController
 
   end
 
+  def delete
+
+    logger.debug "User has selected to delete supporting evidence ID: #{params[:supporting_evidence_id]} from project ID: #{@project.id}"
+
+    supporting_evidence = EvidenceOfSupport.find(params[:supporting_evidence_id])
+
+    logger.debug "Deleting supporting evidence ID: #{supporting_evidence.id}"
+
+    supporting_evidence.destroy if supporting_evidence.project_id == @project.id
+
+    logger.debug "Finished deleting supporting evidence ID: #{supporting_evidence.id}"
+
+    redirect_to three_to_ten_k_project_project_support_evidence_path
+
+  end
+
   private
   def project_params
     params.require(:project).permit(evidence_of_support_attributes: [:description, :evidence_of_support_files])

--- a/app/views/project/project_support_evidence/show.html.erb
+++ b/app/views/project/project_support_evidence/show.html.erb
@@ -19,6 +19,7 @@
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">Description</th>
             <th scope="col" class="govuk-table__header">Files</th>
+            <th scope="col" class="govuk-table__header"></th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
@@ -31,6 +32,19 @@
                 <%= link_to(eos.evidence_of_support_files.blob.filename,
                             rails_blob_path(eos.evidence_of_support_files.blob, disposition: "attachment"))
                 %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= form_with model: @project,
+                            url: three_to_ten_k_project_supporting_evidence_delete_path(supporting_evidence_id: eos.id),
+                            method: :delete,
+                            local: true do |f| %>
+
+                <%= f.submit "Delete", class: "govuk-button govuk-button--warning",
+                             "data-module" => "govuk-button", "data-turbolinks" => "false",
+                             "aria-label" => "Delete button"
+                %>
+
+              <% end %>
             </td>
           </tr>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,6 +161,10 @@ Rails.application.routes.draw do
       get ':project_id/evidence-of-support', to: 'project_support_evidence#show', as: :project_support_evidence
       put ':project_id/evidence-of-support', to: 'project_support_evidence#put'
 
+      delete ':project_id/evidence-of-support/:supporting_evidence_id',
+             to: 'project_support_evidence#delete',
+             as: :supporting_evidence_delete
+
       get ':project_id/check-your-answers',
           to: 'project_check_answers#show', as: :check_answers_get
 


### PR DESCRIPTION
This pull request implements the functionality to delete evidence of support that has been added to a project. This follows the same pattern used in #182 for the deletion of project costs.

This method will also remove the related attachment from the active_storage_attachments and active_storage_blobs tables.