### PR TITLE
Added missing error classes to form inputs

### DIFF
--- a/app/views/project/project_non_cash_contributions/show.html.erb
+++ b/app/views/project/project_non_cash_contributions/show.html.erb
@@ -101,7 +101,7 @@
               <%= ncc.label :description, 'Description', class: 'govuk-label' %>
               <%= ncc.text_area :description,
                                 rows: 5,
-                                class: 'govuk-textarea govuk-js-character-count',
+                                class: "govuk-textarea #{'govuk-textarea--error' if @project.errors['non_cash_contributions.description'].any?} govuk-js-character-count",
                                 "aria-describedby" => "project_non_cash_contributions_attributes_0_description-info",
                                 value: "#{flash[:description] if flash[:description].present?}"
               %>
@@ -129,7 +129,7 @@
               <div class="nlhf-currency-denote__capture">
                 <%= ncc.number_field :amount,
                                      min: 1,
-                                     class: 'govuk-input',
+                                     class: "govuk-input #{'govuk-input--error' if @project.errors['non_cash_contributions.amount'].any?}",
                                      "autocomplete" => "off",
                                      value: "#{flash[:amount] if flash[:amount].present?}"
                 %>


### PR DESCRIPTION
This pull request adds missing error classes to form inputs on the non-cash contributions page if relevant errors are present.