### PR TITLE
Tidied organisation type controller and view

### DIFF
--- a/app/controllers/concerns/object_errors_logger.rb
+++ b/app/controllers/concerns/object_errors_logger.rb
@@ -1,0 +1,13 @@
+module ObjectErrorsLogger
+  extend ActiveSupport::Concern
+
+  # This method writes a debug log line for each error found in a model object's errors hash
+  def log_errors(model_object)
+
+    model_object.errors.each do |k, v|
+      logger.debug "Error '#{v}', for key '#{k}'"
+    end
+
+  end
+
+end

--- a/app/controllers/organisation/type_controller.rb
+++ b/app/controllers/organisation/type_controller.rb
@@ -1,38 +1,43 @@
 class Organisation::TypeController < ApplicationController
-  include OrganisationContext
+  include OrganisationContext, ObjectErrorsLogger
 
+  # This method updates the org_type attribute of an organisation,
+  # redirecting to :organisation_numbers if successful and re-rendering
+  # :show method if unsuccessful
   def update
 
-    logger.debug "Attempting to update organisation ID: #{@organisation.id} "
+    logger.info "Updating org_type for organisation ID: #{@organisation.id}"
 
     @organisation.validate_org_type = true
 
-    @organisation.update(organisation_type_params)
+    @organisation.update(organisation_params)
 
     if @organisation.valid?
+
+      logger.info "Finished updating org_type for organisation ID: #{@organisation.id}"
 
       redirect_to :organisation_numbers
 
     else
 
-      logger.debug "Organisation type not found when attempting to update organisation ID: " +
-                       "#{@organisation.id}"
+      logger.info "Validation failed when attempting to update org_type for organisation ID: #{@organisation.id}"
+
+      log_errors(@organisation)
 
       render :show
 
     end
 
-    logger.debug "Finished updating organisation ID: #{@organisation.id}"
-
   end
 
   private
+  def organisation_params
 
-  def organisation_type_params
-
-    if !params[:organisation].present?
-      params.merge!({organisation: {org_type: ""}})
-    end
+    # When no radio button is selected on the page no org_type key/value is passed in the form,
+    # meaning that the organisation hash is no longer passed through either. In this case, we
+    # need to add it manually to avoid triggering a 'param is missing or value is empty'
+    # exception
+    params.merge!(organisation: {org_type: ""}) unless params[:organisation].present?
 
     params.require(:organisation).permit(:org_type)
 

--- a/app/views/organisation/type/show.html.erb
+++ b/app/views/organisation/type/show.html.erb
@@ -1,24 +1,33 @@
+<%=
+  render partial: "partials/page_title",
+         locals: {
+             model_object: @organisation,
+             page_title: "What type of organisation will be running your project?"
+         }
+%>
 
-<% content_for :page_title, @organisation.errors.any? ? "Error: Type of organisation" : "Type of organisation" %>
+<%=
+  render partial: "partials/summary_errors",
+         locals: {
+             form_object: @organisation,
+             first_form_element: :organisation_org_type_registered_charity
+         } if @organisation.errors.any?
+%>
 
-<%= render partial: "partials/summary_errors", locals: {
-    form_object: @organisation,
-    first_form_element: :organisation_org_type_registered_charity
-} if @organisation.errors.any? %>
-
-<%= form_with model: @organisation, url: organisation_type_path, method: :put do |f|  %>
+<%= form_with model: @organisation, url: :organisation_type, method: :put, local: true do |f|  %>
 
   <div class="govuk-form-group <%= "govuk-form-group--error" if @organisation.errors.any? %>">
 
     <fieldset class="govuk-fieldset">
 
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
         <h1 class="govuk-fieldset__heading">
           What type of organisation will be running your project?
         </h1>
       </legend>
 
-      <%= render partial: "partials/form_group_errors", locals: {form_object: @organisation} if @organisation.errors.any? %>
+      <%= render partial: "partials/form_group_errors", locals: {form_object: @organisation} if
+              @organisation.errors.any? %>
 
       <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
 
@@ -39,12 +48,14 @@
 
         <div class="govuk-radios__item">
           <%= f.radio_button :org_type, "community_interest_company", class: "govuk-radios__input" %>
-          <%= f.label :org_type_community_interest_company, "Community Interest Company", class: "govuk-label govuk-radios__label" %>
+          <%= f.label :org_type_community_interest_company,
+                      "Community Interest Company", class: "govuk-label govuk-radios__label" %>
         </div>
 
         <div class="govuk-radios__item">
           <%= f.radio_button :org_type, "faith_based_organisation", class: "govuk-radios__input" %>
-          <%= f.label :org_type_faith_based_organisation, "Faith-based organisation", class: "govuk-label govuk-radios__label" %>
+          <%= f.label :org_type_faith_based_organisation,
+                      "Faith-based organisation", class: "govuk-label govuk-radios__label" %>
         </div>
 
         <div class="govuk-radios__item">
@@ -64,7 +75,8 @@
 
         <div class="govuk-radios__item">
           <%= f.radio_button :org_type, "individual_private_owner_of_heritage", class: "govuk-radios__input" %>
-          <%= f.label :org_type_individual_private_owner_of_heritage, "Individual private owner of heritage", class: "govuk-label govuk-radios__label" %>
+          <%= f.label :org_type_individual_private_owner_of_heritage,
+                      "Individual private owner of heritage", class: "govuk-label govuk-radios__label" %>
         </div>
 
         <div class="govuk-radios__item">
@@ -76,9 +88,11 @@
 
         <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
              id="conditional-organisation_org_type_other">
+
           <p class="govuk-body">
             Other types of organisations also have to satisfy our applicant funding criteria.
           </p>
+
         </div>
 
       </div>
@@ -87,6 +101,12 @@
 
   </div>
 
-  <%= f.submit "Save and continue", class:'govuk-button', role: 'button', 'aria-label' => 'save and continue button' %>
+  <%=
+    f.submit "Save and continue",
+               class: 'govuk-button',
+               role: 'button',
+               'aria-label' => 'save and continue button',
+               'data-module' => 'govuk-button'
+  %>
 
 <% end %>

--- a/app/views/partials/_page_title.html.erb
+++ b/app/views/partials/_page_title.html.erb
@@ -1,0 +1,4 @@
+<%
+  content_for :page_title,
+              model_object.errors.any? ? "Error: #{page_title}" : page_title
+%>


### PR DESCRIPTION
This pull request contains some general tidying and slight refactoring of the controller and view for the 'What type of organisation will be running your project' page.

I've created a partial to be used for the `title` element of each page, which is implemented here.

As well, I've created a generic `ObjectErrorsLogger` class with a `log_errors` method that we can use to log any object validation errors at a `debug` level.