### PR TITLE
enforce legal signatory is different than main contact

### DIFF
--- a/app/models/legal_signatory.rb
+++ b/app/models/legal_signatory.rb
@@ -1,4 +1,13 @@
+class IsNotSameAsMainContactValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value == User.find_by(organisation_id: record.organisation).email
+      record.errors[attribute] << (options[:message] || "must be different to your email address")
+    end
+  end
+end
+
 class LegalSignatory < ApplicationRecord
+  belongs_to :organisation
   self.implicit_order_column = "created_at"
 
   attr_accessor :validate_name
@@ -6,7 +15,7 @@ class LegalSignatory < ApplicationRecord
   attr_accessor :validate_phone_number
 
   validates :name, presence: true, if: :validate_name?
-  validates :email_address, presence: true, if: :validate_email_address?
+  validates :email_address, presence: true, is_not_same_as_main_contact: true, if: :validate_email_address?
   validates :phone_number, presence: true, if: :validate_phone_number?
 
   def validate_name?


### PR DESCRIPTION
This is a workaround to the issue described in https://trello.com/c/Eh8gqH6y/1072-trustee-email-cannot-match-main-contact-email