### PR TITLE
Removed validation of organisation charity number

### DIFF
--- a/app/controllers/organisation/numbers_controller.rb
+++ b/app/controllers/organisation/numbers_controller.rb
@@ -10,7 +10,6 @@ class Organisation::NumbersController < ApplicationController
                      "setting company_number and charity_number"
 
     @organisation.validate_company_number = true
-    @organisation.validate_charity_number = true
 
     @organisation.update(company_number: company_number, charity_number: charity_number)
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -5,13 +5,11 @@ class Organisation < ApplicationRecord
 
   attr_accessor :validate_org_type
   attr_accessor :validate_company_number
-  attr_accessor :validate_charity_number
   attr_accessor :validate_address
   attr_accessor :validate_mission
 
   validates :org_type, presence: true, if: :validate_org_type?
   validates :company_number, numericality: {only_integer: true}, allow_blank: true, if: :validate_company_number?
-  validates :charity_number, numericality: {only_integer: true}, allow_blank: true, if: :validate_charity_number?
   validate :validate_mission_array, if: :validate_mission?
   validates :name, presence: true, if: :validate_address?
   validates :line1, presence: true, if: :validate_address?
@@ -25,10 +23,6 @@ class Organisation < ApplicationRecord
 
   def validate_company_number?
     validate_company_number == true
-  end
-
-  def validate_charity_number?
-    validate_charity_number == true
   end
 
   def validate_address?

--- a/app/views/organisation/numbers/show.html.erb
+++ b/app/views/organisation/numbers/show.html.erb
@@ -37,7 +37,7 @@
     <%= render partial: "partials/form_input_errors",
                locals: {form_object: @organisation,
                         input_field_id: :charity_number} if @organisation.errors[:charity_number].any? %>
-    <%= f.number_field :charity_number, class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if @organisation.errors[:charity_number].any?}" %>
+    <%= f.text_field :charity_number, class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if @organisation.errors[:charity_number].any?}" %>
 
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,8 +75,6 @@ en-GB:
               blank: "Select the type of organisation that will be running your project"
             company_number:
               not_a_number: "Company number must be a number, like 12345678"
-            charity_number:
-              not_a_number: "Charity number must be a number, like 1079639"
             name:
               blank: "Enter the name of your organisation"
             line1:

--- a/db/migrate/20200128141927_change_charity_number_column_type.rb
+++ b/db/migrate/20200128141927_change_charity_number_column_type.rb
@@ -1,0 +1,5 @@
+class ChangeCharityNumberColumnType < ActiveRecord::Migration[6.0]
+  def change
+    change_column :organisations, :charity_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_23_142350) do
+ActiveRecord::Schema.define(version: 2020_01_28_141927) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -98,7 +98,7 @@ ActiveRecord::Schema.define(version: 2020_01_23_142350) do
     t.string "county"
     t.string "postcode"
     t.integer "company_number"
-    t.integer "charity_number"
+    t.string "charity_number"
     t.integer "charity_number_ni"
     t.string "name"
     t.string "line2"


### PR DESCRIPTION
This pull request removes validation of an organisation's charity number. This came from the following note from Alice:

> Scottish Charities have letters in them, not just numbers