### PR TITLE
Fixed label for evidence of support files upload field

### DIFF
--- a/app/views/project/project_support_evidence/show.html.erb
+++ b/app/views/project/project_support_evidence/show.html.erb
@@ -86,9 +86,7 @@
 
       <div class="nlhf-add-item__row">
         <div class="govuk-form-group" id="file-upload-group">
-          <label class="govuk-label" for="evidence-upload">
-            Upload a file
-          </label>
+          <%= e.label :evidence_of_support_files, "Upload a file", class: "govuk-label" %>
           <%= e.file_field :evidence_of_support_files, multiple: false, direct_upload: true, class: 'govuk-file-upload' %>
         </div>
       </div>


### PR DESCRIPTION
This pull request fixes an issue with the `label` element on the Evidence of support page. @Jo-Arthur-NLHF reported that the file upload field was not being read out well by screen reader software - I've investigated and the label wasn't correctly attributed to the input field. Hopefully this will fix the issue.

See https://trello.com/c/8LFdLLIJ for context.