### PR TITLE
Silence healthcheck

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,3 +84,5 @@ gem "delayed_job_web", "~> 1.4"
 
 
 gem "lograge", "~> 0.11.2"
+
+gem "silencer", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,7 @@ GEM
       rubyzip (>= 1.2.2)
     sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
+    silencer (1.0.1)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -351,6 +352,7 @@ DEPENDENCIES
   sass-rails (< 6)
   selenium-webdriver
   sentry-raven (~> 2.13)
+  silencer (~> 1.0)
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/config/initializers/silencer.rb
+++ b/config/initializers/silencer.rb
@@ -1,0 +1,10 @@
+require 'silencer/logger'
+
+Rails.application.configure do
+  config.middleware.swap(
+      Rails::Rack::Logger,
+      Silencer::Logger,
+      config.log_tags,
+      silence: ["/health"]
+  )
+end


### PR DESCRIPTION
This is a way to reduce log-noise as cloudfoundry is constantly hitting healthcheck endpoint. This is one of the suggestions of papertrail: https://help.papertrailapp.com/kb/configuration/controlling-verbosity#reduce-noise