### PR TITLE
Added flag to enable non-JS journey on Evidence of support page

### DIFF
--- a/app/controllers/project/project_support_evidence_controller.rb
+++ b/app/controllers/project/project_support_evidence_controller.rb
@@ -1,9 +1,9 @@
 class Project::ProjectSupportEvidenceController < ApplicationController
-  include ProjectContext
+  include ProjectContext, ObjectErrorsLogger
 
   def put
 
-    logger.debug "Adding evidence of support for project ID: #{@project.id}"
+    logger.info "Adding evidence of support for project ID: #{@project.id}"
 
     @project.validate_evidence_of_support = true
 
@@ -11,13 +11,15 @@ class Project::ProjectSupportEvidenceController < ApplicationController
 
     if @project.valid?
 
-      logger.debug "Finished adding evidence of support for project ID: #{@project.id}"
+      logger.info "Finished adding evidence of support for project ID: #{@project.id}"
 
       redirect_to three_to_ten_k_project_project_support_evidence_path
 
     else
 
-      logger.debug "Validation failed when adding evidence of support for project ID: #{@project.id}"
+      logger.info "Validation failed when adding evidence of support for project ID: #{@project.id}"
+
+      log_errors(@project)
 
       render :show
 

--- a/app/views/project/project_support_evidence/show.html.erb
+++ b/app/views/project/project_support_evidence/show.html.erb
@@ -1,4 +1,43 @@
-<% content_for :page_title, @project.errors.any? ? "Error: Evidence of support" : "Evidence of support" %>
+<%=
+  render partial: "partials/page_title",
+         locals: {
+             model_object: @project,
+             page_title: "Evidence of support"
+         }
+%>
+
+<noscript><% no_js = true %></noscript>
+
+<%# TODO: Split this into a partial %>
+<% if @project.errors.any? %>
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title"
+       role="alert" tabindex="-1" data-module="govuk-error-summary">
+
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
+
+    <div class="govuk-error-summary__body">
+
+      <ul class="govuk-list govuk-error-summary__list">
+
+        <% @project.errors.each do |attr, msg| %>
+          <% unless attr.to_s == "evidence_of_support" %>
+            <li>
+              <a data-turbolinks='false'
+                 href='#project_evidence_of_support_attributes_0_<%= "#{attr.to_s.split('.')[1]}" %>'>
+                <%= msg %>
+              </a>
+            </li>
+          <% end %>
+        <% end %>
+
+      </ul>
+
+    </div>
+
+  </div>
+<% end %>
 
 <div id="summary-errors"></div>
 
@@ -54,7 +93,7 @@
   </div>
 </section>
 
-<%= form_with model: @project, url: three_to_ten_k_project_project_support_evidence_path, method: :put, remote: true do |f| %>
+<%= form_with model: @project, url: three_to_ten_k_project_project_support_evidence_path, method: :put, remote: no_js ? false : true do |f| %>
 
   <% f.fields_for :evidence_of_support, @project.evidence_of_support.build do |e| %>
 
@@ -68,15 +107,33 @@
 
       <div class="nlhf-add-item__row">
         <div class="govuk-character-count" data-module="govuk-character-count" data-maxwords="50">
-          <div class="govuk-form-group" id="evidence-description-form-group">
+          <div class="govuk-form-group <%= "govuk-form-group--error" if
+                                               @project.errors['evidence_of_support.description'].any? %>"
+               id="evidence-description-form-group">
+
+            <%= render partial: "partials/form_input_errors",
+                       locals: {
+                           form_object: @project,
+                           input_field_id: :'evidence_of_support.description'} if
+                    @project.errors['evidence_of_support.description'].any?
+            %>
 
             <div id="evidence-description-errors"></div>
 
             <label class="govuk-label" for="evidence-description">
               Describe the evidence you are providing
             </label>
-            <%= e.text_area :description, value: "", class: 'govuk-textarea govuk-js-character-count', rows: 5 %>
-            <span id="project_evidence_of_support_attributes_0_description-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
+
+            <%=
+              e.text_area :description,
+                          value: "",
+                          class: "govuk-textarea govuk-js-character-count #{'govuk-textarea--error' if
+                              @project.errors['evidence_of_support.description'].any?}",
+                          rows: 5
+            %>
+
+            <span id="project_evidence_of_support_attributes_0_description-info"
+                  class="govuk-hint govuk-character-count__message" aria-live="polite">
               You have 50 words remaining
             </span>
           </div>
@@ -85,9 +142,26 @@
       <!-- / nlhf-add-item__row -->
 
       <div class="nlhf-add-item__row">
-        <div class="govuk-form-group" id="file-upload-group">
+        <div class="govuk-form-group <%= "govuk-form-group--error" if
+                                             @project.errors['evidence_of_support.evidence_of_support_files'].any? %>"
+             id="file-upload-group">
+
+          <%= render partial: "partials/form_input_errors",
+                     locals: {
+                         form_object: @project,
+                         input_field_id: :'evidence_of_support.evidence_of_support_files'} if
+                  @project.errors['evidence_of_support.evidence_of_support_files'].any?
+          %>
+
           <%= e.label :evidence_of_support_files, "Upload a file", class: "govuk-label" %>
-          <%= e.file_field :evidence_of_support_files, multiple: false, direct_upload: true, class: 'govuk-file-upload' %>
+          <%=
+            e.file_field :evidence_of_support_files,
+                         multiple: false,
+                         direct_upload: true,
+                         class: "govuk-file-upload #{'govuk-file-upload--error' if
+                             @project.errors['evidence_of_support.evidence_of_support_files'].any?}"
+          %>
+
         </div>
       </div>
       <!-- / nlhf-add-item__row -->


### PR DESCRIPTION
Similar to #223 .

Note that we're reusing code here from other forms with nested attributes in order to display the errors summary group, which we'll split out into a partial at some stage.