### PR TITLE
set long cache time for assets on production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,6 +13,9 @@ Rails.application.configure do
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
+  config.public_file_server.headers = {
+      'Cache-Control' => "public, max-age=31536000"
+  }
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).


### PR DESCRIPTION
Makes sense to do this now we have CloudFront on production, see https://guides.rubyonrails.org/asset_pipeline.html#cdns-and-the-cache-control-header