### PR TITLE
Added email validation to legal signatory model and controller

### DIFF
--- a/app/models/legal_signatory.rb
+++ b/app/models/legal_signatory.rb
@@ -15,7 +15,10 @@ class LegalSignatory < ApplicationRecord
   attr_accessor :validate_phone_number
 
   validates :name, presence: true, if: :validate_name?
-  validates :email_address, presence: true, is_not_same_as_main_contact: true, if: :validate_email_address?
+  validates :email_address,
+            format: { with: URI::MailTo::EMAIL_REGEXP },
+            is_not_same_as_main_contact: true,
+            if: :validate_email_address?
   validates :phone_number, presence: true, if: :validate_phone_number?
 
   def validate_name?

--- a/app/models/legal_signatory.rb
+++ b/app/models/legal_signatory.rb
@@ -15,6 +15,9 @@ class LegalSignatory < ApplicationRecord
   attr_accessor :validate_phone_number
 
   validates :name, presence: true, if: :validate_name?
+  # TODO: Abstract email address validation into a single place,
+  #       able to reference all email fields within the application
+  #       See: https://github.com/heritagefund/funding-frontend/issues/244
   validates :email_address,
             format: { with: URI::MailTo::EMAIL_REGEXP },
             is_not_same_as_main_contact: true,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,7 +91,7 @@ en-GB:
             name:
               blank: "Enter the name of a legal signatory"
             email_address:
-              blank: "Enter the email address of a legal signatory"
+              invalid: "Enter a valid email address"
             phone_number:
               blank: "Enter the phone number of a legal signatory"
         project:


### PR DESCRIPTION
This looks like the simplest way to add this in for now - although it will allow email addresses through in the format of `name@mailserver`, for example.

Note that it is no longer necessary to validate `presence: true` for this field, as it already triggers as part of the email validation. Leaving it in results in two error messages being displayed when no email address is added.