### PR TITLE
Removal of individual data-turbolinks attributes

### DIFF
--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -29,10 +29,12 @@
 
 <% end %>
 
-<a href="<%= start_a_project_url %>" role="button" data-turbolinks="false"  draggable="false" class="govuk-button govuk-button--start"
-   data-module="govuk-button" aria-label="Start a new project">
+<a href="<%= start_a_project_url %>" role="button" draggable="false"
+   class="govuk-button govuk-button--start" data-module="govuk-button"
+   aria-label="Start a new project">
   Start a new project
-  <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40"
+  <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg"
+       width="17.5" height="19" viewBox="0 0 33 40"
        role="presentation" focusable="false">
     <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
   </svg>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -9,8 +9,9 @@
 
 <p class="govuk-body">Apply for funding from the National Lottery Heritage fund for your heritage project</p>
 
-<a href="<%= @start_now_link_value %>" role="button" draggable="false" class="govuk-button govuk-button--start"
-   data-module="govuk-button" aria-label="Start now" data-prevent-double-click="true" data-turbolinks="false">
+<a href="<%= @start_now_link_value %>" role="button" draggable="false"
+   class="govuk-button govuk-button--start" data-module="govuk-button"
+   aria-label="Start now" data-prevent-double-click="true">
   Start Now
   <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40"
        role="presentation" focusable="false">

--- a/app/views/organisation/signatories/show.html.erb
+++ b/app/views/organisation/signatories/show.html.erb
@@ -15,7 +15,9 @@
         <% @legal_signatories.each do |signatory| %>
           <% signatory.errors.each do |attr, msg| %>
             <li>
-              <a data-turbolinks="false" href=<%="#legal_signatories_#{signatory.id}_#{attr}" %>><%= msg %></a>
+              <a href=<%="#legal_signatories_#{signatory.id}_#{attr}" %>>
+                <%= msg %>
+              </a>
             </li>
           <% end %>
         <% end %>

--- a/app/views/organisation/summary/show.html.erb
+++ b/app/views/organisation/summary/show.html.erb
@@ -18,7 +18,7 @@
       <%= link_to "Change<span class='govuk-visually-hidden'> organisation type</span>".html_safe,
                   :organisation_type,
                   organisation_id: @organisation.id,
-                  class: "govuk-link govuk-link--no-visited-state"  %>
+                  class: "govuk-link govuk-link--no-visited-state" %>
     </dd>
 
   </div>
@@ -56,7 +56,7 @@
       <%= link_to "Change<span class='govuk-visually-hidden'> charity number</span>".html_safe,
                   :organisation_numbers,
                   organisation_id: @organisation.id,
-                  class: "govuk-link govuk-link--no-visited-state"  %>
+                  class: "govuk-link govuk-link--no-visited-state" %>
     </dd>
 
   </div>
@@ -75,7 +75,7 @@
       <%= link_to "Change<span class='govuk-visually-hidden'> location</span>".html_safe,
                   :organisation_about,
                   organisation_id: @organisation.id,
-                  class: "govuk-link govuk-link--no-visited-state"  %>
+                  class: "govuk-link govuk-link--no-visited-state" %>
     </dd>
 
   </div>
@@ -100,7 +100,7 @@
       <%= link_to "Change<span class='govuk-visually-hidden'> mission or objectives</span>".html_safe,
                   :organisation_mission,
                   organisation_id: @organisation.id,
-                  class: "govuk-link govuk-link--no-visited-state"  %>
+                  class: "govuk-link govuk-link--no-visited-state" %>
     </dd>
 
   </div>
@@ -125,7 +125,7 @@
       <%= link_to "Change<span class='govuk-visually-hidden'> legal signatories</span>".html_safe,
                   :organisation_signatories,
                   organisation_id: @organisation.id,
-                  class: "govuk-link govuk-link--no-visited-state"  %>
+                  class: "govuk-link govuk-link--no-visited-state" %>
     </dd>
 
   </div>
@@ -141,6 +141,6 @@
 
 <a href="<%= "#{three_to_ten_k_project_create_url}" %>" role="button" draggable="false" class="govuk-button govuk-button--start"
    data-module="govuk-button" aria-label="Continue button"
-   data-turbolinks="false">
+   >
   Save and continue
 </a>

--- a/app/views/partials/_file_upload_error_summary.html.erb
+++ b/app/views/partials/_file_upload_error_summary.html.erb
@@ -1,4 +1,5 @@
-<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+<div class="govuk-error-summary" aria-labelledby="error-summary-title"
+     role="alert" tabindex="-1" data-module="govuk-error-summary">
 
   <h2 class="govuk-error-summary__title" id="error-summary-title">
     There is a problem
@@ -7,7 +8,7 @@
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list">
       <li>
-        <a data-turbolinks='false' href='#file-upload-form-group'>
+        <a href='#file-upload-form-group'>
           <%= t('errors.views.file_upload_error_message') %>
         </a>
       </li>

--- a/app/views/partials/_summary_errors.html.erb
+++ b/app/views/partials/_summary_errors.html.erb
@@ -1,4 +1,5 @@
-<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+<div class="govuk-error-summary" aria-labelledby="error-summary-title"
+     role="alert" tabindex="-1" data-module="govuk-error-summary">
 
   <h2 class="govuk-error-summary__title" id="error-summary-title">
     There is a problem
@@ -10,8 +11,8 @@
 
       <% form_object.errors.each do |attr, msg| %>
         <li>
-          <a data-turbolinks='false' href='#<%= form_object.errors.size == 1 ? first_form_element :
-                                                    "#{form_object.class.name.downcase}_#{attr.to_s}" %>'>
+          <a href='#<%= form_object.errors.size == 1 ? first_form_element :
+                            "#{form_object.class.name.downcase}_#{attr.to_s}" %>'>
             <%= msg %>
           </a>
         </li>

--- a/app/views/partials/_summary_errors_flash.html.erb
+++ b/app/views/partials/_summary_errors_flash.html.erb
@@ -1,4 +1,5 @@
-<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+<div class="govuk-error-summary" aria-labelledby="error-summary-title"
+     role="alert" tabindex="-1" data-module="govuk-error-summary">
 
   <h2 class="govuk-error-summary__title" id="error-summary-title">
     There is a problem
@@ -10,7 +11,9 @@
 
       <% flash[:errors].each do |attr, msg| %>
         <li>
-          <a data-turbolinks="false" href="#<%= flash[:errors].size > 1 ? attr : first_form_element  %>"><%= msg %></a>
+          <a href="#<%= flash[:errors].size > 1 ? attr : first_form_element  %>">
+            <%= msg %>
+          </a>
         </li>
       <% end %>
 

--- a/app/views/project/project_capital_works/show.html.erb
+++ b/app/views/project/project_capital_works/show.html.erb
@@ -9,7 +9,7 @@
     first_form_element: :project_capital_work_false
 } if @project.errors.any? %>
 
-<%= form_for @project, url: three_to_ten_k_project_capital_works_put_path, method: :put, remote: no_js ? false : true do |f| %>
+<%= form_with model: @project, url: three_to_ten_k_project_capital_works_put_path, method: :put, remote: no_js ? false : true do |f| %>
 
   <div id="capital-works-form-group-main" class="govuk-form-group <%= "govuk-form-group--error" if @project.errors.any? %>">
 

--- a/app/views/project/project_cash_contribution/show.html.erb
+++ b/app/views/project/project_cash_contribution/show.html.erb
@@ -24,8 +24,7 @@
         <% @project.errors.each do |attr, msg| %>
           <% unless attr.to_s == "cash_contributions" %>
             <li>
-              <a data-turbolinks='false'
-                 href='#project_cash_contributions_attributes_0_<%= "#{attr.to_s.split('.')[1]}" %>'>
+              <a href='#project_cash_contributions_attributes_0_<%= "#{attr.to_s.split('.')[1]}" %>'>
                 <%= msg %>
               </a>
             </li>
@@ -86,8 +85,9 @@
                             method: :delete,
                             local: true do |f| %>
 
-                <%= f.submit "Delete", class: "govuk-button govuk-button--warning",
-                             "data-module" => "govuk-button", "data-turbolinks" => "false",
+                <%= f.submit "Delete",
+                             class: "govuk-button govuk-button--warning",
+                             "data-module" => "govuk-button",
                              "aria-label" => "Delete button"
                 %>
 

--- a/app/views/project/project_costs/show.html.erb
+++ b/app/views/project/project_costs/show.html.erb
@@ -14,7 +14,7 @@
 
         <% if @project.errors.size == 1 && @project.errors[:project_costs].any? %>
           <li>
-            <a data-turbolinks='false' href='#project_project_costs_attributes_0_cost_type'>
+            <a href='#project_project_costs_attributes_0_cost_type'>
               <%= @project.errors.messages[:project_costs][0] %>
             </a>
           </li>
@@ -24,10 +24,10 @@
 
           <% unless attr.to_s == "project_costs" %>
             <li>
-              <a data-turbolinks='false' href='#project_project_costs_attributes_0_<%= "#{attr.to_s.split('.')[1]}" %>'>
+              <a href='#project_project_costs_attributes_0_<%= "#{attr.to_s.split('.')[1]}" %>'>
                 <%= msg %>
               </a>
-            </li>
+            </li>w
           <% end %>
 
         <% end %>
@@ -100,8 +100,9 @@
                             method: :delete,
                             local: true do |f| %>
 
-                <%= f.submit "Delete", class: "govuk-button govuk-button--warning",
-                             "data-module" => "govuk-button", "data-turbolinks" => "false",
+                <%= f.submit "Delete",
+                             class: "govuk-button govuk-button--warning",
+                             "data-module" => "govuk-button",
                              "aria-label" => "Delete button"
                 %>
 

--- a/app/views/project/project_non_cash_contributions/show.html.erb
+++ b/app/views/project/project_non_cash_contributions/show.html.erb
@@ -15,7 +15,7 @@
         <% @project.errors.each do |attr, msg| %>
           <% unless attr.to_s == "non_cash_contributions" %>
           <li>
-            <a data-turbolinks='false' href='#project_non_cash_contributions_attributes_0_<%= "#{attr.to_s.split('.')[1]}" %>'>
+            <a href='#project_non_cash_contributions_attributes_0_<%= "#{attr.to_s.split('.')[1]}" %>'>
               <%= msg %>
             </a>
           </li>
@@ -70,7 +70,7 @@
                             local: true do |f| %>
 
                 <%= f.submit "Delete", class: "govuk-button govuk-button--warning",
-                             "data-module" => "govuk-button", "data-turbolinks" => "false",
+                             "data-module" => "govuk-button",
                              "aria-label" => "Delete button"
                 %>
               <% end %>

--- a/app/views/project/project_support_evidence/show.html.erb
+++ b/app/views/project/project_support_evidence/show.html.erb
@@ -24,8 +24,7 @@
         <% @project.errors.each do |attr, msg| %>
           <% unless attr.to_s == "evidence_of_support" %>
             <li>
-              <a data-turbolinks='false'
-                 href='#project_evidence_of_support_attributes_0_<%= "#{attr.to_s.split('.')[1]}" %>'>
+              <a href='#project_evidence_of_support_attributes_0_<%= "#{attr.to_s.split('.')[1]}" %>'>
                 <%= msg %>
               </a>
             </li>
@@ -78,8 +77,9 @@
                             method: :delete,
                             local: true do |f| %>
 
-                <%= f.submit "Delete", class: "govuk-button govuk-button--warning",
-                             "data-module" => "govuk-button", "data-turbolinks" => "false",
+                <%= f.submit "Delete",
+                             class: "govuk-button govuk-button--warning",
+                             "data-module" => "govuk-button",
                              "aria-label" => "Delete button"
                 %>
 

--- a/app/views/project/project_volunteers/show.html.erb
+++ b/app/views/project/project_volunteers/show.html.erb
@@ -15,7 +15,7 @@
         <% @project.errors.each do |attr, msg| %>
           <% unless attr.to_s == "volunteers" %>
             <li>
-              <a data-turbolinks='false' href='#project_volunteers_attributes_0_<%= "#{attr.to_s.split('.')[1]}" %>'>
+              <a href='#project_volunteers_attributes_0_<%= "#{attr.to_s.split('.')[1]}" %>'>
                 <%= msg %>
               </a>
             </li>
@@ -69,8 +69,9 @@
                           method: :delete,
                           local: true do |f| %>
 
-              <%= f.submit "Delete", class: "govuk-button govuk-button--warning",
-                           "data-module" => "govuk-button", "data-turbolinks" => "false",
+              <%= f.submit "Delete",
+                           class: "govuk-button govuk-button--warning",
+                           "data-module" => "govuk-button",
                            "aria-label" => "Delete button"
               %>
             <% end %>


### PR DESCRIPTION
As we're now setting this site-wide, there is no need to include individual `data-turbolinks` attributes across the application. This pull request removes each of these individual uses.