### PR TITLE
add custom form builder

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  default_form_builder(NlhfFormBuilder)
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,4 @@
 module ApplicationHelper
+  require_relative './nlhf_form_builder'
   include Project::CalculateTotalHelper
 end

--- a/app/helpers/nlhf_form_builder.rb
+++ b/app/helpers/nlhf_form_builder.rb
@@ -1,0 +1,28 @@
+class NlhfFormBuilder < ActionView::Helpers::FormBuilder
+  
+  # Helper method to return 'name' attribute
+  # e.g. f.name_for :description
+  def name_for(method, options = {})
+    InstanceTag.new(object_name, method, self, options) \
+               .name_for(options)
+  end
+
+  # Helper method to return 'id' attribute
+  # e.g. f.id_for :description
+  def id_for(method, options = {})
+    InstanceTag.new(object_name, method, self, options) \
+               .id_for(options)
+  end
+end
+
+class InstanceTag < ActionView::Helpers::Tags::Base
+  def id_for(options)
+    add_default_name_and_id(options)
+    options['id']
+  end
+
+  def name_for(options)
+    add_default_name_and_id(options)
+    options['name']
+  end
+end


### PR DESCRIPTION
Adds a custom form builder and sets it as default. In discussion with @paulmsmith for now we only have helpers to expose the rails generated ID and name, which can be used in conjunction with vanilla partials. This is a building block to enable @paulmsmith to building more reusable components.