### PR TITLE
Added integration tests for organisation summary controller

### DIFF
--- a/spec/controllers/organisation/summary_controller_spec.rb
+++ b/spec/controllers/organisation/summary_controller_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe Organisation::SummaryController do
+  login_user
+
+  describe "GET #show" do
+
+    it "should render the page successfully for a valid organisation" do
+      get :show,
+          params: { organisation_id: subject.current_user.organisation.id }
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:show)
+      expect(assigns(:organisation).errors.empty?).to eq(true)
+    end
+
+    it "should redirect to root for an invalid organisation" do
+      get :show, params: { organisation_id: "invalid" }
+      expect(response).to have_http_status(:redirect)
+      expect(response).to redirect_to(:root)
+    end
+
+  end
+
+end


### PR DESCRIPTION
This pull request adds integration tests for the `organisation/summary_controller`. Note that there is only a `GET` route for this controller.