### PR TITLE
Refactoring of legal signatories

### DIFF
--- a/app/controllers/organisation/signatories_controller.rb
+++ b/app/controllers/organisation/signatories_controller.rb
@@ -1,90 +1,73 @@
 class Organisation::SignatoriesController < ApplicationController
-  include OrganisationContext
-  before_action :set_legal_signatories
+  include OrganisationContext, ObjectErrorsLogger
+
+  def show
+
+    @organisation.legal_signatories.build unless
+        @organisation.legal_signatories.first.present?
+    @organisation.legal_signatories.build unless
+        @organisation.legal_signatories.second.present?
+
+  end
 
   def update
 
-    logger.debug "Updating legal signatories for organisation ID: #{@organisation.id}"
+    logger.info "Updating legal signatories for organisation ID: " \
+                 "#{@organisation.id}"
 
-    set_signatory_validation_paramaters
+    @organisation.validate_legal_signatories = true
 
-    signatory_validation_statuses = []
+    @organisation.update(organisation_params)
 
-    @legal_signatories.each do |signatory|
+    if @organisation.valid?
 
-      logger.debug "Assigning attributes for legal signatory ID: #{signatory.id}"
+      # See method documentation for description of why this is necessary
+      remove_empty_signatory
 
-      signatory.assign_attributes({
-                           name: params[:legal_signatories][signatory.id][:name],
-                           email_address: params[:legal_signatories][signatory.id][:email_address],
-                           phone_number: params[:legal_signatories][signatory.id][:phone_number]
-                       })
+      logger.info "Finished updating legal signatories for organisation ID: " \
+                   "#{@organisation.id}"
 
-      logger.debug "Finished assigning attributes for legal signatory ID: #{signatory.id}"
-
-      signatory_validation_statuses << signatory.valid?
-
-    end
-
-    if signatory_validation_statuses.include?(false)
-
-      logger.debug "Validation checks failed for one or more legal signatory updates"
-
-      render :show
+      redirect_to :organisation_summary
 
     else
 
-      logger.debug "Finished updating legal signatories for organisation ID: #{@organisation.id}"
+      logger.info "Validation failed for one or more legal signatory " \
+                   "updates for organisation ID: #{@organisation.id}"
 
-      @legal_signatories.each do |signatory|
-        signatory.save
-      end
+      log_errors(@organisation)
 
-      redirect_to :organisation_summary
+      render :show
 
     end
 
   end
 
   private
-
-  def set_legal_signatories
-
-    @legal_signatories = LegalSignatory.where(organisation_id: @organisation.id)
-
-    if @legal_signatories.present?
-
-      logger.debug "Found existing legal signatories for organisation ID: #{@organisation.id}"
-
-    else
-
-      logger.debug "Creating legal signatories for organisation ID: #{@organisation.id}"
-
-      @legal_signatories = [LegalSignatory.create(organisation_id: @organisation.id),
-                            LegalSignatory.create(organisation_id: @organisation.id)]
-
-      logger.debug "Finished creating legal signatories for organisation ID: #{@organisation.id}"
-
-    end
-
+  def organisation_params
+    params.require(:organisation).permit(
+        legal_signatories_attributes: [
+            :id,
+            :name,
+            :email_address,
+            :phone_number
+        ]
+    )
   end
 
-  def set_signatory_validation_paramaters
+  private
+  # Method used to remove the empty second legal signatory object created
+  # by the nested form. This is necessary as it doesn't seem to be possible
+  # to validate a first nested object and reject the second if no params have
+  # been filled. We can refactor to simply reject both when mandatory
+  # entry of at least one signatory has been removed from this page
+  def remove_empty_signatory
 
-    # The first legal signatory is mandatory, so enable validation
-    @legal_signatories[0].validate_name = true
-    @legal_signatories[0].validate_email_address = true
-    @legal_signatories[0].validate_phone_number = true
+    unless @organisation.legal_signatories.second.name.present? &&
+        @organisation.legal_signatories.second.email_address.present? &&
+        @organisation.legal_signatories.second.phone_number.present?
 
-    # Only enable validation for the second legal signatory if any attributes have been passed
-    if (
-    params[:legal_signatories][params[:legal_signatories].keys[1]][:name].present? ||
-        params[:legal_signatories][params[:legal_signatories].keys[1]][:email_address].present? ||
-        params[:legal_signatories][params[:legal_signatories].keys[1]][:phone_number].present?
-    )
-      @legal_signatories[1].validate_name = true
-      @legal_signatories[1].validate_email_address = true
-      @legal_signatories[1].validate_phone_number = true
+      @organisation.legal_signatories.second.destroy
+
     end
 
   end

--- a/app/controllers/organisation/signatories_controller.rb
+++ b/app/controllers/organisation/signatories_controller.rb
@@ -21,9 +21,6 @@ class Organisation::SignatoriesController < ApplicationController
 
     if @organisation.valid?
 
-      # See method documentation for description of why this is necessary
-      remove_empty_signatory
-
       logger.info "Finished updating legal signatories for organisation ID: " \
                    "#{@organisation.id}"
 
@@ -52,24 +49,6 @@ class Organisation::SignatoriesController < ApplicationController
             :phone_number
         ]
     )
-  end
-
-  private
-  # Method used to remove the empty second legal signatory object created
-  # by the nested form. This is necessary as it doesn't seem to be possible
-  # to validate a first nested object and reject the second if no params have
-  # been filled. We can refactor to simply reject both when mandatory
-  # entry of at least one signatory has been removed from this page
-  def remove_empty_signatory
-
-    unless @organisation.legal_signatories.second.name.present? &&
-        @organisation.legal_signatories.second.email_address.present? &&
-        @organisation.legal_signatories.second.phone_number.present?
-
-      @organisation.legal_signatories.second.destroy
-
-    end
-
   end
 
 end

--- a/app/models/legal_signatory.rb
+++ b/app/models/legal_signatory.rb
@@ -14,6 +14,10 @@ class LegalSignatory < ApplicationRecord
   attr_accessor :validate_email_address
   attr_accessor :validate_phone_number
 
+  after_validation do
+    self.delete if ignore_validation_for_empty_second_signatory?(self)
+  end
+
   validates :name, presence: true,
             unless: lambda {
                 |record| ignore_validation_for_empty_second_signatory?(record)

--- a/app/models/legal_signatory.rb
+++ b/app/models/legal_signatory.rb
@@ -14,15 +14,35 @@ class LegalSignatory < ApplicationRecord
   attr_accessor :validate_email_address
   attr_accessor :validate_phone_number
 
-  validates :name, presence: true, if: :validate_name?
+  validates :name, presence: true,
+            unless: lambda {
+                |record| ignore_validation_for_empty_second_signatory?(record)
+            }
   # TODO: Abstract email address validation into a single place,
   #       able to reference all email fields within the application
   #       See: https://github.com/heritagefund/funding-frontend/issues/244
   validates :email_address,
             format: { with: URI::MailTo::EMAIL_REGEXP },
             is_not_same_as_main_contact: true,
-            if: :validate_email_address?
-  validates :phone_number, presence: true, if: :validate_phone_number?
+            unless: lambda {
+                |record| ignore_validation_for_empty_second_signatory?(record)
+            }
+  validates :phone_number,
+            presence: true,
+            unless: lambda {
+                |record| ignore_validation_for_empty_second_signatory?(record)
+            }
+
+  # Method used to determine whether a legal signatory should not
+  # be validated. We check for this as the first legal signatory is mandatory,
+  # whereas the second only needs to be validated if any of the record's
+  # attributes have been populated
+  def ignore_validation_for_empty_second_signatory?(record)
+    record.name.blank? &&
+        record.email_address.blank? &&
+        record.phone_number.blank? &&
+        record == organisation.legal_signatories.second
+  end
 
   def validate_name?
     validate_name == true

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -3,9 +3,15 @@ class Organisation < ApplicationRecord
   has_many :users
   has_many :legal_signatories
 
+  accepts_nested_attributes_for :legal_signatories
+
   attr_accessor :validate_org_type
   attr_accessor :validate_address
   attr_accessor :validate_mission
+  attr_accessor :validate_legal_signatories
+
+  validates_associated :legal_signatories,
+                       if: :validate_legal_signatories?
 
   validates :org_type, presence: true, if: :validate_org_type?
   validate :validate_mission_array, if: :validate_mission?
@@ -25,6 +31,10 @@ class Organisation < ApplicationRecord
 
   def validate_mission?
     validate_mission == true
+  end
+
+  def validate_legal_signatories?
+    validate_legal_signatories == true
   end
 
   # Custom validator to determine whether any of the items in the incoming mission array

--- a/app/views/organisation/signatories/show.html.erb
+++ b/app/views/organisation/signatories/show.html.erb
@@ -1,8 +1,15 @@
-<% content_for :page_title, @legal_signatories.any? { |legal_signatory| legal_signatory.errors.present?} ? "Error: Who is your legal signatory?" : "Who is your legal signatory?" %>
+<%=
+  render partial: "partials/page_title",
+         locals: {
+             model_object: @organisation,
+             page_title: "Who is your legal signatory?"
+         }
+%>
 
-<% if @legal_signatories.any? { |legal_signatory| legal_signatory.errors.present? } %>
-
-  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+<%# TODO: Split this into a partial %>
+<% if @organisation.errors.any? %>
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title"
+       role="alert" tabindex="-1" data-module="govuk-error-summary">
 
     <h2 class="govuk-error-summary__title" id="error-summary-title">
       There is a problem
@@ -12,14 +19,20 @@
 
       <ul class="govuk-list govuk-error-summary__list">
 
-        <% @legal_signatories.each do |signatory| %>
-          <% signatory.errors.each do |attr, msg| %>
+        <% @organisation.legal_signatories.first.errors.each do |attr, msg| %>
             <li>
-              <a href=<%="#legal_signatories_#{signatory.id}_#{attr}" %>>
+              <a href='#organisation_legal_signatories_attributes_0_<%= attr %>'>
                 <%= msg %>
               </a>
             </li>
-          <% end %>
+        <% end %>
+
+        <% @organisation.legal_signatories.second.errors.each do |attr, msg| %>
+          <li>
+            <a href='#organisation_legal_signatories_attributes_1_<%= attr %>'>
+              <%= msg %>
+            </a>
+          </li>
         <% end %>
 
       </ul>
@@ -27,10 +40,11 @@
     </div>
 
   </div>
-
 <% end %>
 
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-5" aria-label="Heading">Who is your legal signatory?</h1>
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-5" aria-label="Heading">
+  Who is your legal signatory?
+</h1>
 
 <p class="govuk-body" id="legal-signatory-1-fieldset-hint">
   A signatory is a person who is authorised to sign legal documents on behalf
@@ -39,50 +53,104 @@
 
 <p class="govuk-body govuk-!-margin-bottom-7">
   We expect an organisation to have 2 legal signatories. However, we can
-  accept 1 signatory in some limited cases, <a href="https://www.heritagefund.org.uk/about/contact-us" target="_blank">contact us</a> to discuss your application.
+  accept 1 signatory in some limited cases,
+  <a href="https://www.heritagefund.org.uk/about/contact-us" target="_blank">
+    contact us</a> to discuss your application.
 </p>
 
-<%= form_tag(organisation_signatories_path, {method: :put}) do %>
+<%=
+  form_with model: @organisation,
+            url: :organisation_signatories,
+            method: :put,
+            local: true do |f|
+%>
 
-  <% @legal_signatories.each_with_index do |signatory, i| %>
+  <%= f.fields_for :legal_signatories do |ls| %>
 
-    <fieldset class="govuk-fieldset govuk-!-margin-bottom-6" id=<%= "legal-signatory-#{i+1}-fieldset" %>>
+    <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
 
-    <%= fields_for "legal_signatories[]", signatory do |signatory_field| %>
+      <h2 class="govuk-heading-m" aria-label="Heading">
+        <%#
+            We are using ls.index + 1 here to display '1' and '2'
+            as :legal_signatories is zero-indexed
+        %>
+        Legal signatory <%= ls.index + 1 %>
+      </h2>
 
-      <h2 class="govuk-heading-m" aria-label="Heading">Legal signatory <%= i+1 %></h2>
+      <div class="govuk-form-group <%= "#{'govuk-form-group--error' if
+          @organisation.legal_signatories[ls.index].errors[:name].any?}" %>">
 
-      <div class="govuk-form-group">
-        <%= signatory_field.label :name, "Full name", class: "govuk-label" %>
-        <%= render partial: "partials/form_input_errors",
-                   locals: {form_object: signatory,
-                            input_field_id: :name} if signatory.errors[:name].any? %>
-        <%= signatory_field.text_field :name, class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if signatory.errors[:name].any?}" %>
+        <%=
+          render partial: "partials/form_input_errors",
+                 locals: {
+                     form_object: @organisation.legal_signatories[ls.index],
+                     input_field_id: :name
+                 } if @organisation.legal_signatories[ls.index].errors[:name].any?
+        %>
+
+        <%= ls.label :name, "Full name", class: "govuk-label" %>
+
+        <%=
+          ls.text_field :name,
+                        class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if
+                            @organisation.legal_signatories[ls.index].errors[:name].any?}"
+        %>
       </div>
 
-      <div class="govuk-form-group">
-        <%= signatory_field.label :email_address, "Email address", class: "govuk-label" %>
-        <%= render partial: "partials/form_input_errors",
-                   locals: {form_object: signatory,
-                            input_field_id: :email_address} if signatory.errors[:email_address].any? %>
-        <%= signatory_field.text_field :email_address, class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if signatory.errors[:email_address].any?}" %>
+      <div class="govuk-form-group <%= "#{'govuk-form-group--error' if
+          @organisation.legal_signatories[ls.index].errors[:email_address].any?}"
+      %>">
+
+        <%=
+          render partial: "partials/form_input_errors",
+                 locals: {
+                     form_object: @organisation.legal_signatories[ls.index],
+                     input_field_id: :email_address
+                 } if @organisation.legal_signatories[ls.index].errors[:email_address].any?
+        %>
+
+        <%= ls.label :email_address, "Email address", class: "govuk-label" %>
+
+        <%=
+          ls.text_field :email_address,
+                        class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if
+                            @organisation.legal_signatories[ls.index].errors[:email_address].any?}"
+        %>
       </div>
 
-      <div class="govuk-form-group">
-        <%= signatory_field.label :phone_number, "Phone number", class: "govuk-label" %>
-        <%= render partial: "partials/form_input_errors",
-                   locals: {form_object: signatory,
-                            input_field_id: :phone_number} if signatory.errors[:phone_number].any? %>
-        <%= signatory_field.text_field :phone_number, class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if signatory.errors[:phone_number].any?}" %>
-      </div>
+      <div class="govuk-form-group <%= "#{'govuk-form-group--error' if
+          @organisation.legal_signatories[ls.index].errors[:phone_number].any?}"
+      %>">
 
-      
-    <% end %>
+        <%=
+          render partial: "partials/form_input_errors",
+                 locals: {
+                     form_object: @organisation.legal_signatories[ls.index],
+                     input_field_id: :phone_number
+                 } if @organisation.legal_signatories[ls.index].errors[:phone_number].any?
+        %>
+
+        <%= ls.label :phone_number, "Phone number", class: "govuk-label" %>
+
+        <%=
+          ls.text_field :phone_number,
+                        class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if
+                            @organisation.legal_signatories[ls.index].errors[:phone_number].any?}"
+        %>
+
+      </div>
 
     </fieldset>
 
   <% end %>
 
-  <%= submit_tag "Save and continue", {class:'govuk-button', role: 'button', 'aria-label' => 'save and continue button'} %>
+  <%=
+    f.submit "Save and continue",
+             {
+                 class:'govuk-button',
+                 role: 'button',
+                 'aria-label' => 'save and continue button'
+             }
+  %>
 
 <% end %>

--- a/app/views/organisation/signatories/show.html.erb
+++ b/app/views/organisation/signatories/show.html.erb
@@ -19,20 +19,14 @@
 
       <ul class="govuk-list govuk-error-summary__list">
 
-        <% @organisation.legal_signatories.first.errors.each do |attr, msg| %>
+        <% @organisation.legal_signatories.each_with_index do |ls, index| %>
+          <% ls.errors.each do |attr, msg| %>
             <li>
-              <a href='#organisation_legal_signatories_attributes_0_<%= attr %>'>
+              <a href='#organisation_legal_signatories_attributes_<%= index %>_<%= attr %>'>
                 <%= msg %>
               </a>
             </li>
-        <% end %>
-
-        <% @organisation.legal_signatories.second.errors.each do |attr, msg| %>
-          <li>
-            <a href='#organisation_legal_signatories_attributes_1_<%= attr %>'>
-              <%= msg %>
-            </a>
-          </li>
+          <% end %>
         <% end %>
 
       </ul>
@@ -144,13 +138,6 @@
 
   <% end %>
 
-  <%=
-    f.submit "Save and continue",
-             {
-                 class:'govuk-button',
-                 role: 'button',
-                 'aria-label' => 'save and continue button'
-             }
-  %>
+  <%= f.save_and_continue %>
 
 <% end %>


### PR DESCRIPTION
This pull request contains refactoring of the organisation legal signatories model, view, and controller. We have refactored the view to use the same nested attributes pattern used elsewhere throughout the service.

Note that a new private method has been included in the controller which will remove a second legal signatory if it has been added with empty attributes. We are only required to validate the second legal signatory if it has been passed through the form with no attributes populated. This is possible, and has been enabled using a lambda in the legal_signatory model. However, when ignoring validation, Rails will attempt to store the record - it's possible to reject a nested model on the parent model, but it isn't possible to specify the parameters for this rejection, i.e. only reject the second nested model passed through. Because of this, we're always choosing not to validate the second nested model if it hasn't been populated, but Rails will then save an almost-empty record to the database (auto-generated attributes are still populated, such as created_at, etc).

The remove_empty_signatory method is therefore necessary to clean up after ourselves when we have chosen not to validate the second empty legal signatory.

We have discussed making neither legal signatory mandatory at this point, depending on how the mandatory version tests. If that is the case, we can refactor this controller and related models again to reject all empty objects, something which isn't possible at the moment, as discussed above.