### PR TITLE
Added missing fields to organisation summary view

### DIFF
--- a/app/views/organisation/summary/show.html.erb
+++ b/app/views/organisation/summary/show.html.erb
@@ -1,4 +1,10 @@
-<% content_for :page_title, "Organisation summary" %>
+<%=
+  render partial: "partials/page_title",
+         locals: {
+             model_object: @organisation,
+             page_title: "Organisation summary"
+         }
+%>
 
 <h1 class="govuk-heading-xl" aria-label="Heading">Check your answers</h1>
 
@@ -11,14 +17,18 @@
     </dt>
 
     <dd class="govuk-summary-list__value">
-      <%= @organisation.org_type&.humanize %>
+      <%= @organisation.org_type.present? ?
+              @organisation.org_type&.humanize : "Not answered" %>
     </dd>
 
     <dd class="govuk-summary-list__actions">
-      <%= link_to "Change<span class='govuk-visually-hidden'> organisation type</span>".html_safe,
-                  :organisation_type,
-                  organisation_id: @organisation.id,
-                  class: "govuk-link govuk-link--no-visited-state" %>
+      <%=
+        link_to "Change<span class='govuk-visually-hidden'>
+        organisation type</span>".html_safe,
+                :organisation_type,
+                organisation_id: @organisation.id,
+                class: "govuk-link govuk-link--no-visited-state"
+      %>
     </dd>
 
   </div>
@@ -30,14 +40,18 @@
     </dt>
 
     <dd class="govuk-summary-list__value">
-      <%= @organisation.company_number %>
+      <%= @organisation.company_number.present? ?
+              @organisation.company_number : "Not answered" %>
     </dd>
 
     <dd class="govuk-summary-list__actions">
-      <%= link_to "Change<span class='govuk-visually-hidden'> company number</span>".html_safe,
-                  :organisation_numbers,
-                  organisation_id: @organisation.id,
-                  class: "govuk-link govuk-link--no-visited-state" %>
+      <%=
+        link_to "Change<span class='govuk-visually-hidden'>
+         company number</span>".html_safe,
+                :organisation_numbers,
+                organisation_id: @organisation.id,
+                class: "govuk-link govuk-link--no-visited-state"
+      %>
     </dd>
 
   </div>
@@ -49,14 +63,40 @@
     </dt>
 
     <dd class="govuk-summary-list__value">
-      <%= @organisation.charity_number %>
+      <%= @organisation.charity_number.present? ?
+              @organisation.charity_number : "Not answered" %>
     </dd>
 
     <dd class="govuk-summary-list__actions">
-      <%= link_to "Change<span class='govuk-visually-hidden'> charity number</span>".html_safe,
-                  :organisation_numbers,
-                  organisation_id: @organisation.id,
-                  class: "govuk-link govuk-link--no-visited-state" %>
+      <%=
+        link_to "Change<span class='govuk-visually-hidden'>
+         charity number</span>".html_safe,
+                :organisation_numbers,
+                organisation_id: @organisation.id,
+                class: "govuk-link govuk-link--no-visited-state"
+      %>
+    </dd>
+
+  </div>
+
+  <div class="govuk-summary-list__row">
+
+    <dt class="govuk-summary-list__key">
+      Organisation's name
+    </dt>
+
+    <dd class="govuk-summary-list__value">
+      <%= @organisation.name.present? ? @organisation.name : "Not answered" %>
+    </dd>
+
+    <dd class="govuk-summary-list__actions">
+      <%=
+        link_to "Change<span class='govuk-visually-hidden'> name</span>"
+                    .html_safe,
+                :organisation_about,
+                organisation_id: @organisation.id,
+                class: "govuk-link govuk-link--no-visited-state"
+      %>
     </dd>
 
   </div>
@@ -68,14 +108,31 @@
     </dt>
 
     <dd class="govuk-summary-list__value">
-      <%= @organisation.line1 %>
+      <% unless @organisation.line1.present? %>
+        Not answered
+      <% else %>
+        <%= "#{@organisation.line1 } <br />".html_safe if
+                @organisation.line1.present? %>
+        <%= "#{@organisation.line2 } <br />".html_safe if
+                @organisation.line2.present? %>
+        <%= "#{@organisation.line3 } <br />".html_safe if
+                @organisation.line3.present? %>
+        <%= "#{@organisation.townCity } <br />".html_safe if
+                @organisation.townCity.present? %>
+        <%= "#{@organisation.county } <br />".html_safe if
+                @organisation.county.present? %>
+        <%= @organisation.postcode if @organisation.townCity.present? %>
+      <% end %>
     </dd>
 
     <dd class="govuk-summary-list__actions">
-      <%= link_to "Change<span class='govuk-visually-hidden'> location</span>".html_safe,
-                  :organisation_about,
-                  organisation_id: @organisation.id,
-                  class: "govuk-link govuk-link--no-visited-state" %>
+      <%=
+        link_to "Change<span class='govuk-visually-hidden'> location</span>"
+                    .html_safe,
+                :organisation_about,
+                organisation_id: @organisation.id,
+                class: "govuk-link govuk-link--no-visited-state"
+      %>
     </dd>
 
   </div>
@@ -88,19 +145,27 @@
 
     <dd class="govuk-summary-list__value">
       <ul class="govuk-list">
-        <% @organisation.mission.each do |mission| %>
-          <li>
-            <%= mission&.humanize %>
-          </li>
+
+        <% unless @organisation.mission.present? %>
+          Not answered
+        <% else %>
+          <% @organisation.mission.each do |mission| %>
+            <li>
+              <%= mission&.humanize %>
+            </li>
+          <% end %>
         <% end %>
       </ul>
     </dd>
 
     <dd class="govuk-summary-list__actions">
-      <%= link_to "Change<span class='govuk-visually-hidden'> mission or objectives</span>".html_safe,
-                  :organisation_mission,
-                  organisation_id: @organisation.id,
-                  class: "govuk-link govuk-link--no-visited-state" %>
+      <%=
+        link_to "Change<span class='govuk-visually-hidden'>
+         mission or objectives</span>".html_safe,
+                :organisation_mission,
+                organisation_id: @organisation.id,
+                class: "govuk-link govuk-link--no-visited-state"
+      %>
     </dd>
 
   </div>
@@ -113,19 +178,26 @@
 
     <dd class="govuk-summary-list__value">
       <ul class="govuk-list">
-        <% @organisation.legal_signatories.each do |legal_signatory| %>
-          <li>
-            <%= legal_signatory.name %>
-          </li>
+        <% unless @organisation.legal_signatories.present? %>
+          Not answered
+        <% else %>
+          <% @organisation.legal_signatories.each do |legal_signatory| %>
+            <li>
+              <%= legal_signatory.name %>
+            </li>
+          <% end %>
         <% end %>
       </ul>
     </dd>
 
     <dd class="govuk-summary-list__actions">
-      <%= link_to "Change<span class='govuk-visually-hidden'> legal signatories</span>".html_safe,
-                  :organisation_signatories,
-                  organisation_id: @organisation.id,
-                  class: "govuk-link govuk-link--no-visited-state" %>
+      <%=
+        link_to "Change<span class='govuk-visually-hidden'>
+         legal signatories</span>".html_safe,
+                :organisation_signatories,
+                organisation_id: @organisation.id,
+                class: "govuk-link govuk-link--no-visited-state"
+      %>
     </dd>
 
   </div>
@@ -135,12 +207,13 @@
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Declaration</span>
-    By saving this information you are confirming, that to the best of your knowledge, the details you are providing are correct.
+    By saving this information you are confirming, that to the best of your
+    knowledge, the details you are providing are correct.
   </strong>
 </div>
 
-<a href="<%= "#{three_to_ten_k_project_create_url}" %>" role="button" draggable="false" class="govuk-button govuk-button--start"
-   data-module="govuk-button" aria-label="Continue button"
-   >
+<a href="<%= "#{three_to_ten_k_project_create_url}" %>"
+   role="button" draggable="false" class="govuk-button govuk-button--start"
+   data-module="govuk-button" aria-label="Continue button">
   Save and continue
 </a>


### PR DESCRIPTION
The organisation summary view previously did not contain a row for the organisation's name, nor did it contain the whole address for an organisation - only the first line. This commit addresses both of these issues, as well as tidying up the markup in order to pass RuboCop line length validation when we bring this in.