### PR TITLE
Added extra Postgres environment variables to GitHub Action

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -6,92 +6,95 @@ jobs:
   build:
     name: build, test and deploy (on master only)
     runs-on: ubuntu-latest
-    
+
     services:
       postgres:
         image: postgres:11
         env:
           POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: funding_frontend_test
         ports:
-        - 5432:5432
+          - 5432:5432
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-    steps: 
-    - name: 'Install Postgres client'
-      run: sudo apt-get -yqq install libpq-dev
-    - uses: actions/checkout@master
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '12.x'
-    - uses: actions/setup-ruby@v1
-      with:
-        ruby-version: '2.6'
-    - name: Get yarn cache
-      id: yarn-cache
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+    steps:
+      - name: 'Install Postgres client'
+        run: sudo apt-get -yqq install libpq-dev
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-    - uses: actions/cache@v1
-      with:
-        path: ${{ steps.yarn-cache.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-    - run: yarn install
-    - run: gem install bundler
-    - name: Cache Gemfile dependencies
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems
-    - name: Bundle install
-      run: |
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
-    - name: Run tests 
-      env:
-        PGHOST: localhost
-        PGUSER: postgres
-        RAILS_ENV: test
-      run: |
-        bin/rails db:setup
-        ./bin/rails test
-        bundle exec rspec
-    
-    - name: Install the CF CLI
-      if: github.ref == 'refs/heads/master'
-      run: |
-        wget https://s3-us-west-1.amazonaws.com/cf-cli-releases/releases/v6.48.0/cf-cli-installer_6.48.0_x86-64.deb
-        sudo dpkg -i cf-cli-installer_6.48.0_x86-64.deb
-    - name: Cloudfoundry auth
-      if: github.ref == 'refs/heads/master'
-      env:
-        CF_USERNAME: ${{ secrets.CF_USERNAME }}
-        CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      run: |
-        cf api https://api.london.cloud.service.gov.uk
-        cf auth
-        cf target -o national-lottery-heritage-fund
-    - name: Deploy to staging
-      if: github.ref == 'refs/heads/master'
-      env:
-        CF_APP: funding-frontend-staging
-        CF_SPACE: sandbox
-        CF_MANIFEST: staging
-      run: |
-        cf target -s ${CF_SPACE}
-        cf v3-cancel-zdt-push ${CF_APP} || true
-        cf v3-apply-manifest -f manifest-${CF_MANIFEST}.yml
-        cf v3-zdt-push ${CF_APP}  --wait-for-deploy-complete
-    - name: Deploy to production
-      if: github.ref == 'refs/heads/master'
-      env:
-        CF_APP: funding-frontend
-        CF_SPACE: production
-        CF_MANIFEST: production
-      run: |
-        cf target -s ${CF_SPACE}
-        cf v3-cancel-zdt-push ${CF_APP} || true
-        cf v3-apply-manifest -f manifest-${CF_MANIFEST}.yml
-        cf v3-zdt-push ${CF_APP}  --wait-for-deploy-complete
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install
+      - run: gem install bundler
+      - name: Cache Gemfile dependencies
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Run tests
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          RAILS_ENV: test
+        run: |
+          bin/rails db:setup
+          ./bin/rails test
+          bundle exec rspec
+
+      - name: Install the CF CLI
+        if: github.ref == 'refs/heads/master'
+        run: |
+          wget https://s3-us-west-1.amazonaws.com/cf-cli-releases/releases/v6.48.0/cf-cli-installer_6.48.0_x86-64.deb
+          sudo dpkg -i cf-cli-installer_6.48.0_x86-64.deb
+      - name: Cloudfoundry auth
+        if: github.ref == 'refs/heads/master'
+        env:
+          CF_USERNAME: ${{ secrets.CF_USERNAME }}
+          CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+        run: |
+          cf api https://api.london.cloud.service.gov.uk
+          cf auth
+          cf target -o national-lottery-heritage-fund
+      - name: Deploy to staging
+        if: github.ref == 'refs/heads/master'
+        env:
+          CF_APP: funding-frontend-staging
+          CF_SPACE: sandbox
+          CF_MANIFEST: staging
+        run: |
+          cf target -s ${CF_SPACE}
+          cf v3-cancel-zdt-push ${CF_APP} || true
+          cf v3-apply-manifest -f manifest-${CF_MANIFEST}.yml
+          cf v3-zdt-push ${CF_APP}  --wait-for-deploy-complete
+      - name: Deploy to production
+        if: github.ref == 'refs/heads/master'
+        env:
+          CF_APP: funding-frontend
+          CF_SPACE: production
+          CF_MANIFEST: production
+        run: |
+          cf target -s ${CF_SPACE}
+          cf v3-cancel-zdt-push ${CF_APP} || true
+          cf v3-apply-manifest -f manifest-${CF_MANIFEST}.yml
+          cf v3-zdt-push ${CF_APP}  --wait-for-deploy-complete


### PR DESCRIPTION
Our continuous integration workflow GitHub Action started to fail, reporting an error of 'Failed to initialize, postgres service is unhealthy.'.

Searching for the error found that this seems to be a relatively common occurence with GitHub Actions, with no reason given as to why. However, the fix seems to be as simple as adding extra necessary environment variables to the PostgreSQL service - in this case, we already had POSTGRES_USER, but were not setting POSTGRES_PASSWORD or POSTGRES_DB. This commit adds in the missing environment variables, and also sets the PGPASSWORD environment variable for the 'Run tests' step.

See https://github.community/t5/GitHub-Actions/Mysql-service-never-comes-up-healthy-in-action/td-p/38283.