### PR TITLE
Addition of application payload log

### DIFF
--- a/app/jobs/application_to_salesforce_job.rb
+++ b/app/jobs/application_to_salesforce_job.rb
@@ -18,6 +18,7 @@ class ApplicationToSalesforceJob < ApplicationJob
         api_version: '47.0'
     )
     @json = project.to_salesforce_json
+    logger.info "Payload JSON to be sent to Salesforce is: #{@json}"
     @response = client.post('/services/apexrest/PortalData', @json,  {'Content-Type'=>'application/json'})
     @response_body_obj = JSON.parse(@response&.body)
     is_successful = @response_body_obj&.dig('status') == 'Success'


### PR DESCRIPTION
This commit adds an additional log line to log out the application payload which is being sent to Salesforce.

This will enable us to determine whether the main contact date of birth is being set in production.