### PR TITLE
Moved user research declaration to confirm declaration page

### DIFF
--- a/app/controllers/project/declaration_controller.rb
+++ b/app/controllers/project/declaration_controller.rb
@@ -48,8 +48,6 @@ class Project::DeclarationController < ApplicationController
 
     @project.validate_is_partnership = true
 
-    logger.debug @project.is_partnership
-
     if params[:project].present?
       if params[:project][:is_partnership].present?
         @project.validate_partnership_details = true if
@@ -87,7 +85,10 @@ class Project::DeclarationController < ApplicationController
       params.merge!({project: {confirm_declaration: ""}})
     end
 
-    params.require(:project).permit(:confirm_declaration)
+    params.require(:project).permit(
+        :confirm_declaration,
+        :user_research_declaration
+    )
 
   end
 
@@ -95,7 +96,6 @@ class Project::DeclarationController < ApplicationController
 
     params.require(:project).permit(
         :declaration_reasons_description,
-        :user_research_declaration,
         :keep_informed_declaration,
         :is_partnership,
         :partnership_details

--- a/app/views/project/declaration/show_confirm_declaration.html.erb
+++ b/app/views/project/declaration/show_confirm_declaration.html.erb
@@ -42,7 +42,33 @@
 
     <div class="govuk-checkboxes">
 
+      <p class="govuk-body">
+        We run qualitative user research to help us to develop our products and
+        services. This could be from a 20 minute survey to a 2 hour interview.
+      </p>
+
       <div class="govuk-checkboxes__item">
+
+        <%=
+          f.check_box :user_research_declaration,
+                      {
+                          id: :project_user_research_declaration,
+                          class: "govuk-checkboxes__input"
+                      },
+                      'true', 'false'
+        %>
+
+        <%=
+          f.label :user_research_declaration,
+                  "Tick this box if you would like to be involved in our " \
+                  "research, or find out more.",
+                  class: "govuk-label govuk-checkboxes__label"
+        %>
+
+      </div>
+
+      <div class="govuk-checkboxes__item">
+
         <%=
           f.check_box :confirm_declaration,
                       {
@@ -52,11 +78,13 @@
                       "true",
                       nil
         %>
+
         <%=
           f.label :confirm_declaration,
                     "I have read and agreed with the #{link_to 'declaration', :three_to_ten_k_project_declaration_get}".html_safe,
                     class: "govuk-label govuk-checkboxes__label"
         %>
+
       </div>
 
     </div>

--- a/app/views/project/declaration/show_declaration.html.erb
+++ b/app/views/project/declaration/show_declaration.html.erb
@@ -131,38 +131,6 @@
 
   </ul>
 
-  <p class="govuk-body">
-    We run qualitative user research to help us to develop our products and
-    services. This could be from a 20 minute survey to a 2 hour interview.
-  </p>
-
-  <div class="govuk-form-group">
-
-    <div class="govuk-checkboxes govuk-checkboxes--small">
-
-      <div class="govuk-checkboxes__item">
-
-        <%=
-          f.check_box :user_research_declaration,
-                      {
-                          id: :project_user_research_declaration,
-                          class: "govuk-checkboxes__input"
-                      },
-                      'true', 'false'
-        %>
-
-        <%=
-          f.label :user_research_declaration,
-                  "Tick this box if you would like to be involved in our research, or find out more.",
-                  class: "govuk-label govuk-checkboxes__label"
-        %>
-
-      </div>
-
-    </div>
-
-  </div>
-
   <div class="govuk-form-group">
 
     <p class="govuk-body">

--- a/spec/controllers/project/declaration_controller_spec.rb
+++ b/spec/controllers/project/declaration_controller_spec.rb
@@ -115,6 +115,7 @@ describe Project::DeclarationController do
           params: {
               project_id: project.id,
               project: {
+                  user_research_declaration: "true",
                   confirm_declaration: "true"
               }
           }
@@ -126,6 +127,7 @@ describe Project::DeclarationController do
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).confirm_declaration).to eq("true")
+      expect(assigns(:project).user_research_declaration).to eq(true)
 
     end
 
@@ -195,7 +197,6 @@ describe Project::DeclarationController do
               project: {
                   declaration_reasons_description: "Test",
                   keep_informed_declaration: "false",
-                  user_research_declaration: "true",
                   is_partnership: "false"
               }
           }
@@ -208,7 +209,6 @@ describe Project::DeclarationController do
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).declaration_reasons_description).to eq("Test")
       expect(assigns(:project).keep_informed_declaration).to eq(false)
-      expect(assigns(:project).user_research_declaration).to eq(true)
       expect(assigns(:project).is_partnership).to eq(false)
 
     end
@@ -225,7 +225,6 @@ describe Project::DeclarationController do
               project: {
                   declaration_reasons_description: "Test",
                   keep_informed_declaration: "false",
-                  user_research_declaration: "true",
                   is_partnership: "true"
               }
           }
@@ -248,7 +247,6 @@ describe Project::DeclarationController do
               project: {
                   declaration_reasons_description: "Test",
                   keep_informed_declaration: "true",
-                  user_research_declaration: "false",
                   is_partnership: "true",
                   partnership_details: "Testing"
               }
@@ -262,7 +260,6 @@ describe Project::DeclarationController do
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).declaration_reasons_description).to eq("Test")
       expect(assigns(:project).keep_informed_declaration).to eq(true)
-      expect(assigns(:project).user_research_declaration).to eq(false)
       expect(assigns(:project).is_partnership).to eq(true)
       expect(assigns(:project).partnership_details).to eq("Testing")
 


### PR DESCRIPTION
This commit moves the user research checkbox item from the declaration page to the confirm declaration page. Relevant controllers and integration tests have also been updated.