### PR TITLE
Added missing error elements to capital works view

### DIFF
--- a/app/views/project/capital_works/show.html.erb
+++ b/app/views/project/capital_works/show.html.erb
@@ -102,7 +102,9 @@
             surveyor.
           </span>
 
-          <div class="govuk-form-group" id="file-upload-group">
+          <div id="capital-works.capital_work_files-errors"></div>
+
+          <div class="govuk-form-group" id="capital-works.capital_work_files-form-group">
 
             <%=
               f.label :capital_work_file,

--- a/app/views/project/capital_works/show.js.erb
+++ b/app/views/project/capital_works/show.js.erb
@@ -27,7 +27,7 @@
 
   removeFormGroupErrors(
     "capital-works",
-    ["capital_work_files", "capital_work_file"],
+    ["capital_work_files"],
     errorKeys
   );
 


### PR DESCRIPTION
I had missed adding some of the necessary elements/identifiers to the capital works page when refactoring the AJAX error-handling for this view. I believe that this is the cause of the alerts being raised by Sentry in relation to this page.

I've tested locally with this fix in place and can't produce any JavaScript errors on this page (or the other pages with AJAX error-handling).