### PR TITLE
add basic auth to consumer endpoint

### DIFF
--- a/app/controllers/released_form_controller.rb
+++ b/app/controllers/released_form_controller.rb
@@ -1,4 +1,6 @@
 class ReleasedFormController < ApplicationController
+  http_basic_authenticate_with name: Rails.configuration.x.consumer.username, password: Rails.configuration.x.consumer.password
+
     protect_from_forgery with: :null_session
     def receive
        @project = Project.find(params[:ApplicationId])

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -79,5 +79,6 @@ Rails.application.configure do
 
   config.action_view_component.preview_path =
       "#{Rails.root}/spec/components/previews"
-
+  config.x.consumer.username = 'test'
+  config.x.consumer.password = 'test'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -134,5 +134,7 @@ Rails.application.configure do
   config.x.support_email_address = ENV.fetch("SUPPORT_EMAIL_ADDRESS")
   config.x.delayed_job_web.username = ENV.fetch("DELAYED_JOB_WEB_USERNAME")
   config.x.delayed_job_web.password = ENV.fetch("DELAYED_JOB_WEB_PASSWORD")
+  config.x.consumer.username = ENV.fetch("CONSUMER_USERNAME")
+  config.x.consumer.password = ENV.fetch("CONSUMER_PASSWORD")
 
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -127,5 +127,7 @@ Rails.application.configure do
   config.x.salesforce.host = "test.salesforce.com"
   config.lograge.enabled = true
   config.assets.quiet = true
+  config.x.consumer.username = ENV.fetch("CONSUMER_USERNAME")
+  config.x.consumer.password = ENV.fetch("CONSUMER_PASSWORD")
 
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -55,4 +55,6 @@ Rails.application.configure do
 
   config.x.support_email_address = "test@test.com"
   config.x.ideal_postcodes.api_key = "test"
+  config.x.consumer.username = 'test'
+  config.x.consumer.password = 'test'
 end

--- a/spec/controllers/released_form_controller_spec.rb
+++ b/spec/controllers/released_form_controller_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 describe ReleasedFormController do
+  before(:each) do
+    username = Rails.configuration.x.consumer.username
+    password = Rails.configuration.x.consumer.password
+    request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
+  end
 
   describe "POST #receive" do
 


### PR DESCRIPTION
Salesforce webhook expects basic auth. This is part of https://trello.com/c/JHdiuJOH/1111-capture-salesforce-webhook-json-in-db-medium