### PR TITLE
Added validation for negative integers

### DIFF
--- a/app/models/cash_contribution.rb
+++ b/app/models/cash_contribution.rb
@@ -6,7 +6,10 @@ class CashContribution < ApplicationRecord
   has_one_attached :cash_contribution_evidence_files
 
   validates :description, presence: true
-  validates :amount, numericality: { only_integer: true }
+  validates :amount, numericality: {
+      only_integer: true,
+      greater_than: 0
+  }
   validates_inclusion_of :secured, in: ["yes_with_evidence", "no", "x_not_sure", "yes_no_evidence_yet"]
 
   validate do

--- a/app/models/non_cash_contribution.rb
+++ b/app/models/non_cash_contribution.rb
@@ -3,5 +3,8 @@ class NonCashContribution < ApplicationRecord
   belongs_to :project
 
   validates :description, presence: true
-  validates :amount, numericality: {only_integer: true}
+  validates :amount, numericality: {
+      only_integer: true,
+      greater_than: 0
+  }
 end

--- a/app/models/project_cost.rb
+++ b/app/models/project_cost.rb
@@ -5,7 +5,10 @@ class ProjectCost < ApplicationRecord
   belongs_to :project
 
   validates :cost_type, presence: true
-  validates :amount, numericality: {only_integer: true}
+  validates :amount, numericality: {
+      only_integer: true,
+      greater_than: 0
+  }
   validates :description, presence: true
 
   validate do

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -3,5 +3,8 @@ class Volunteer < ApplicationRecord
   belongs_to :project
 
   validates :description, presence: true
-  validates :hours, numericality: {only_integer: true}
+  validates :hours, numericality: {
+      only_integer: true,
+      greater_than: 0
+  }
 end

--- a/app/views/project/cash_contributions/show.html.erb
+++ b/app/views/project/cash_contributions/show.html.erb
@@ -422,7 +422,8 @@
               <div class="nlhf-currency-denote__capture">
 
                 <%=
-                  cc.number_field :amount,
+                  cc.text_field :amount,
+                                "autocomplete" => "off",
                                   class: "govuk-input govuk-input--width-10 #{'govuk-input--error' if
                                       @project.errors['cash_contributions.amount'].any?}"
                 %>

--- a/app/views/project/non_cash_contributions/show.html.erb
+++ b/app/views/project/non_cash_contributions/show.html.erb
@@ -241,7 +241,7 @@
               <div class="nlhf-currency-denote__capture">
 
                 <%=
-                  ncc.number_field :amount,
+                  ncc.text_field :amount,
                                    min: 1,
                                    class: "govuk-input #{'govuk-input--error' if
                                        @project.errors['non_cash_contributions.amount'].any?}",

--- a/app/views/project/volunteers/show.html.erb
+++ b/app/views/project/volunteers/show.html.erb
@@ -231,6 +231,7 @@
 
             <%=
               v.text_field :hours,
+                           "autocomplete" => "off",
                            class: "govuk-input govuk-input govuk-input--width-10 #{'govuk-input--error' if @project.errors['volunteers.hours'].any?}",
                            value: "#{flash[:hours] if flash[:hours].present?}"
             %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,6 +180,7 @@ en-GB:
               too_long: "Description of your cash contribution must be 50 words or fewer"
             amount:
               not_a_number: "Amount must be a number, like 500"
+              greater_than: "Enter an amount greater than 0"
             secured:
               inclusion: "Select whether or not your cash contribution is secured"
             cash_contribution_evidence_files:
@@ -190,6 +191,7 @@ en-GB:
               blank: "Enter a description of your non-cash contribution"
             amount:
               not_a_number: "Amount must be a number, like 500"
+              greater_than: "Enter an amount greater than 0"
         project_cost:
           attributes:
             description:
@@ -197,6 +199,7 @@ en-GB:
               too_long: "Description of your cost must be 50 words or fewer"
             amount:
               not_a_number: "Amount must be a number, like 500"
+              greater_than: "Enter an amount greater than 0"
             cost_type:
               blank: "Select the cost type for the project cost you are adding"
         volunteer:
@@ -205,6 +208,7 @@ en-GB:
               blank: "Enter a description of your project volunteer"
             hours:
               not_a_number: "Hours must be a number, like 5"
+              greater_than: "Hours must be greater than 0"
         evidence_of_support:
           attributes:
             description:

--- a/spec/controllers/project/cash_contributions_controller_spec.rb
+++ b/spec/controllers/project/cash_contributions_controller_spec.rb
@@ -231,6 +231,76 @@ describe Project::CashContributionsController do
 
     end
 
+    it "should re-render the page if amount param which is not an integer is " \
+       "passed" do
+
+      expect(subject).to \
+        receive(:log_errors).with(project)
+
+      put :update,
+          params: {
+              project_id: project.id,
+              project: {
+                  cash_contributions_attributes: {
+                      "0": {
+                          description: "",
+                          amount: "string",
+                          secured: ""
+                      }
+                  }
+              }
+          }
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:show)
+
+      expect(assigns(:project).errors.empty?).to eq(false)
+      expect(assigns(:project).cash_contributions.first.errors.empty?)
+          .to eq(false)
+      expect(assigns(:project).cash_contributions.first.errors.messages[:amount][0])
+          .to eq(I18n.t("activerecord.errors.models.cash_contribution.attributes.amount.not_a_number"))
+      expect(assigns(:project).cash_contributions.first.errors.messages[:description][0])
+          .to eq(I18n.t("activerecord.errors.models.cash_contribution.attributes.description.blank"))
+      expect(assigns(:project).cash_contributions.first.errors.messages[:secured][0])
+          .to eq(I18n.t("activerecord.errors.models.cash_contribution.attributes.secured.inclusion"))
+
+    end
+
+    it "should re-render the page if amount param which contains a negative " \
+       "number is passed" do
+
+      expect(subject).to \
+        receive(:log_errors).with(project)
+
+      put :update,
+          params: {
+              project_id: project.id,
+              project: {
+                  cash_contributions_attributes: {
+                      "0": {
+                          description: "",
+                          amount: "-50",
+                          secured: ""
+                      }
+                  }
+              }
+          }
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:show)
+
+      expect(assigns(:project).errors.empty?).to eq(false)
+      expect(assigns(:project).cash_contributions.first.errors.empty?)
+          .to eq(false)
+      expect(assigns(:project).cash_contributions.first.errors.messages[:amount][0])
+          .to eq(I18n.t("activerecord.errors.models.cash_contribution.attributes.amount.greater_than"))
+      expect(assigns(:project).cash_contributions.first.errors.messages[:description][0])
+          .to eq(I18n.t("activerecord.errors.models.cash_contribution.attributes.description.blank"))
+      expect(assigns(:project).cash_contributions.first.errors.messages[:secured][0])
+          .to eq(I18n.t("activerecord.errors.models.cash_contribution.attributes.secured.inclusion"))
+
+    end
+
     it "should re-render the page if secured param of 'yes_with_evidence' is " \
        "passed without a file" do
 

--- a/spec/controllers/project/costs_controller_spec.rb
+++ b/spec/controllers/project/costs_controller_spec.rb
@@ -174,6 +174,37 @@ describe Project::CostsController do
 
     end
 
+    it "should re-render the page if an amount attribute which contains a " \
+       "negative number is passed" do
+
+      expect(subject).to \
+        receive(:log_errors).with(project)
+
+      put :update,
+          params: {
+              project_id: project.id,
+              project: {
+                  project_costs_attributes: {
+                      "0": {
+                          cost_type: "new_staff",
+                          description: "Test",
+                          amount: "-50"
+                      }
+                  }
+              }
+          }
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:show)
+
+      expect(assigns(:project).errors.empty?).to eq(false)
+      expect(assigns(:project).project_costs.first.errors.empty?)
+          .to eq(false)
+      expect(assigns(:project).project_costs.first.errors.messages[:amount][0])
+          .to eq(I18n.t("activerecord.errors.models.project_cost.attributes.amount.greater_than"))
+
+    end
+
     it "should re-render the page with a flash message if empty " \
        "description and populated amount attributes are passed" do
 

--- a/spec/controllers/project/non_cash_contributions_controller_spec.rb
+++ b/spec/controllers/project/non_cash_contributions_controller_spec.rb
@@ -256,6 +256,72 @@ describe Project::NonCashContributionsController do
 
     end
 
+    it "should re-render the page with a flash message if an amount param " \
+       "containing a string is passed" do
+
+      expect(subject).to \
+        receive(:log_errors).with(project)
+
+      put :update,
+          params: {
+              project_id: project.id,
+              project: {
+                  non_cash_contributions_attributes: {
+                      "0": {
+                          description: "",
+                          amount: "string"
+                      }
+                  }
+              }
+          }
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:show)
+
+      expect(subject.request.flash[:amount]).to eq("string")
+
+      expect(assigns(:project).errors.empty?).to eq(false)
+      expect(assigns(:project).non_cash_contributions.first.errors.empty?).to eq(false)
+      expect(assigns(:project).non_cash_contributions.first.errors.messages[:amount][0])
+          .to eq(I18n.t("activerecord.errors.models.non_cash_contribution.attributes.amount.not_a_number"))
+      expect(assigns(:project).non_cash_contributions.first.errors.messages[:description][0])
+          .to eq(I18n.t("activerecord.errors.models.non_cash_contribution.attributes.description.blank"))
+
+    end
+
+    it "should re-render the page with a flash message if an amount param " \
+       "containing a negative number is passed" do
+
+      expect(subject).to \
+        receive(:log_errors).with(project)
+
+      put :update,
+          params: {
+              project_id: project.id,
+              project: {
+                  non_cash_contributions_attributes: {
+                      "0": {
+                          description: "",
+                          amount: "-50"
+                      }
+                  }
+              }
+          }
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:show)
+
+      expect(subject.request.flash[:amount]).to eq("-50")
+
+      expect(assigns(:project).errors.empty?).to eq(false)
+      expect(assigns(:project).non_cash_contributions.first.errors.empty?).to eq(false)
+      expect(assigns(:project).non_cash_contributions.first.errors.messages[:amount][0])
+          .to eq(I18n.t("activerecord.errors.models.non_cash_contribution.attributes.amount.greater_than"))
+      expect(assigns(:project).non_cash_contributions.first.errors.messages[:description][0])
+          .to eq(I18n.t("activerecord.errors.models.non_cash_contribution.attributes.description.blank"))
+
+    end
+
     it "should successfully update if valid description and amount " \
        "attributes are passed" do
 

--- a/spec/controllers/project/volunteers_controller_spec.rb
+++ b/spec/controllers/project/volunteers_controller_spec.rb
@@ -176,6 +176,39 @@ describe Project::VolunteersController do
 
     end
 
+    it "should re-render the page with a flash message if populated " \
+       "description and an hours attribute containing a negative number are " \
+       "passed" do
+
+      expect(subject).to \
+        receive(:log_errors).with(project)
+
+      put :update,
+          params: {
+              project_id: project.id,
+              project: {
+                  volunteers_attributes: {
+                      "0": {
+                          description: "Test",
+                          hours: "-50"
+                      }
+                  }
+              }
+          }
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:show)
+
+      expect(subject.request.flash[:description]).to eq("Test")
+      expect(subject.request.flash[:hours]).to eq("-50")
+
+      expect(assigns(:project).errors.empty?).to eq(false)
+      expect(assigns(:project).volunteers.first.errors.empty?).to eq(false)
+      expect(assigns(:project).volunteers.first.errors.messages[:hours][0])
+          .to eq(I18n.t("activerecord.errors.models.volunteer.attributes.hours.greater_than"))
+
+    end
+
     it "should successfully update if valid description and hours attributes " \
        "are passed" do
 


### PR DESCRIPTION
This commit adds validation for fields in the application which capture numerical values. These occur on the following pages - volunteers, non-cash contributions, cash contributions, and project costs. Previously, where no validation occurred, a user could enter a negative integer value and the application would pass this through. This could result in negative values being passed through to Salesforce, or a negative value being displayed on the overall grant request page.

Additionally, I have replaced the remaining numerical fields on the related views with text fields. Originally, we chose to use numerical fields to enable browser-based validation. However, GDS advise not to use input fields with a type attribute of number and to use input fields with a type attribute of text and to validate the value entered. We saw in user testing that the input fields with a type attribute of number do not work well with some assistive technologies.