### PR TITLE
Configure RSpec to no longer expose the DSL globally

### DIFF
--- a/spec/controllers/concerns/organisation_context_spec.rb
+++ b/spec/controllers/concerns/organisation_context_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe OrganisationContext do
+RSpec.describe OrganisationContext do
 
   # To test our controller concerns, we use the concept of an anonymous
   # controller, which allows us to access RSpec methods and helpers.

--- a/spec/controllers/concerns/project_context_spec.rb
+++ b/spec/controllers/concerns/project_context_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ProjectContext do
+RSpec.describe ProjectContext do
 
   # To test our controller concerns, we use the concept of an anonymous
   # controller, which allows us to access RSpec methods and helpers.

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe DashboardController do
+RSpec.describe DashboardController do
 
   describe "GET #health" do
     login_user

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe HealthController do
+RSpec.describe HealthController do
 
   describe "GET #health" do
 

--- a/spec/controllers/organisation/mission_controller_spec.rb
+++ b/spec/controllers/organisation/mission_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Organisation::MissionController do
+RSpec.describe Organisation::MissionController do
   login_user
 
   describe "GET #show" do

--- a/spec/controllers/organisation/numbers_controller_spec.rb
+++ b/spec/controllers/organisation/numbers_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Organisation::NumbersController do
+RSpec.describe Organisation::NumbersController do
   login_user
 
   describe "GET #show" do

--- a/spec/controllers/organisation/signatories_controller_spec.rb
+++ b/spec/controllers/organisation/signatories_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Organisation::SignatoriesController do
+RSpec.describe Organisation::SignatoriesController do
   login_user
 
   describe "GET #show" do

--- a/spec/controllers/organisation/summary_controller_spec.rb
+++ b/spec/controllers/organisation/summary_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Organisation::SummaryController do
+RSpec.describe Organisation::SummaryController do
   login_user
 
   describe "GET #show" do

--- a/spec/controllers/organisation/type_controller_spec.rb
+++ b/spec/controllers/organisation/type_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Organisation::TypeController do
+RSpec.describe Organisation::TypeController do
   login_user
 
   describe "GET #show" do

--- a/spec/controllers/project/accounts_controller_spec.rb
+++ b/spec/controllers/project/accounts_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::AccountsController do
+RSpec.describe Project::AccountsController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/application_submitted_controller_spec.rb
+++ b/spec/controllers/project/application_submitted_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::ApplicationSubmittedController do
+RSpec.describe Project::ApplicationSubmittedController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/best_placed_controller_spec.rb
+++ b/spec/controllers/project/best_placed_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::BestPlacedController do
+RSpec.describe Project::BestPlacedController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/capital_works_controller_spec.rb
+++ b/spec/controllers/project/capital_works_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::CapitalWorksController do
+RSpec.describe Project::CapitalWorksController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/cash_contributions_controller_spec.rb
+++ b/spec/controllers/project/cash_contributions_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::CashContributionsController do
+RSpec.describe Project::CashContributionsController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/check_answers_controller_spec.rb
+++ b/spec/controllers/project/check_answers_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::CheckAnswersController do
+RSpec.describe Project::CheckAnswersController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/costs_controller_spec.rb
+++ b/spec/controllers/project/costs_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::CostsController do
+RSpec.describe Project::CostsController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/dates_controller_spec.rb
+++ b/spec/controllers/project/dates_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::DatesController do
+RSpec.describe Project::DatesController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/declaration_controller_spec.rb
+++ b/spec/controllers/project/declaration_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::DeclarationController do
+RSpec.describe Project::DeclarationController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id, is_partnership: false) }
 

--- a/spec/controllers/project/description_controller_spec.rb
+++ b/spec/controllers/project/description_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::DescriptionController do
+RSpec.describe Project::DescriptionController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/difference_controller_spec.rb
+++ b/spec/controllers/project/difference_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::DifferenceController do
+RSpec.describe Project::DifferenceController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/evidence_of_support_controller_spec.rb
+++ b/spec/controllers/project/evidence_of_support_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::EvidenceOfSupportController do
+RSpec.describe Project::EvidenceOfSupportController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/governing_documents_controller_spec.rb
+++ b/spec/controllers/project/governing_documents_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::GoverningDocumentsController do
+RSpec.describe Project::GoverningDocumentsController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/grant_request_controller_spec.rb
+++ b/spec/controllers/project/grant_request_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::GrantRequestController do
+RSpec.describe Project::GrantRequestController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/heritage_controller_spec.rb
+++ b/spec/controllers/project/heritage_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::HeritageController do
+RSpec.describe Project::HeritageController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/involvement_controller_spec.rb
+++ b/spec/controllers/project/involvement_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::InvolvementController do
+RSpec.describe Project::InvolvementController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/location_controller_spec.rb
+++ b/spec/controllers/project/location_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Project::LocationController do
+RSpec.describe Project::LocationController do
   login_user
   let(:organisation) { create(:organisation, line1: 'line1', line2: 'line2', line3: 'line3', townCity: 'townCity', county: 'county', postcode: 'postcode') }
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id, organisation: organisation) }

--- a/spec/controllers/project/matter_controller_spec.rb
+++ b/spec/controllers/project/matter_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::MatterController do
+RSpec.describe Project::MatterController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/new_project_controller_spec.rb
+++ b/spec/controllers/project/new_project_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::NewProjectController do
+RSpec.describe Project::NewProjectController do
   login_user
 
   describe "GET #create_new_project" do

--- a/spec/controllers/project/non_cash_contributions_controller_spec.rb
+++ b/spec/controllers/project/non_cash_contributions_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::NonCashContributionsController do
+RSpec.describe Project::NonCashContributionsController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/outcomes_controller_spec.rb
+++ b/spec/controllers/project/outcomes_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::OutcomesController do
+RSpec.describe Project::OutcomesController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/permission_controller_spec.rb
+++ b/spec/controllers/project/permission_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::PermissionController do
+RSpec.describe Project::PermissionController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/title_controller_spec.rb
+++ b/spec/controllers/project/title_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::TitleController do
+RSpec.describe Project::TitleController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/project/volunteers_controller_spec.rb
+++ b/spec/controllers/project/volunteers_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Project::VolunteersController do
+RSpec.describe Project::VolunteersController do
   login_user
   let(:project) { create(:project, id: "id", user_id: subject.current_user.id) }
 

--- a/spec/controllers/released_form_controller_spec.rb
+++ b/spec/controllers/released_form_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ReleasedFormController do
+RSpec.describe ReleasedFormController do
   before(:each) do
     username = Rails.configuration.x.consumer.username
     password = Rails.configuration.x.consumer.password

--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe StaticPagesController do
+RSpec.describe StaticPagesController do
 
   describe "GET #show_accessibility_statement" do
     login_user

--- a/spec/helpers/postcode_helper_spec.rb
+++ b/spec/helpers/postcode_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe PostcodeHelper do
+RSpec.describe PostcodeHelper do
 
   describe "#result_formatter" do
 

--- a/spec/helpers/project/calculate_total_helper_spec.rb
+++ b/spec/helpers/project/calculate_total_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Project::CalculateTotalHelper do
+RSpec.describe Project::CalculateTotalHelper do
 
   describe '#calculate_total' do
     it 'adds costs' do

--- a/spec/jobs/application_attachments_to_salesforce_job_spec.rb
+++ b/spec/jobs/application_attachments_to_salesforce_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe ApplicationAttachmentsToSalesforceJob, type: :job do
+RSpec.describe ApplicationAttachmentsToSalesforceJob, type: :job do
   let(:project_with_attachment) {
     project = create(:project)
     project.capital_work_file.attach(io: File.open(Rails.root.join 'spec/fixtures/files/example.txt'), filename: 'example.txt', content_type: 'text/plain')

--- a/spec/jobs/application_to_salesforce_job_spec.rb
+++ b/spec/jobs/application_to_salesforce_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe ApplicationToSalesforceJob, type: :job do
+RSpec.describe ApplicationToSalesforceJob, type: :job do
 
   before(:each) do
     stub_request(:post, "https://test.salesforce.com/services/oauth2/token")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,4 +93,7 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  # Avoid exposing the DSL globally, as this pollutes the global namespace
+  config.expose_dsl_globally = false
 end


### PR DESCRIPTION
As per the GDS Way's Ruby style guide, we should avoid exposing RSpec's domain specific language globally, as this pollutes the global namespace.

This commit configures RSpec to no longer expose the DSL globally, and updates the tests to reflect this.

See: https://gds-way.cloudapps.digital/manuals/programming-languages/ruby.html