### PR TITLE
perform upsert if same form type sent multiple times

### DIFF
--- a/app/jobs/release_form_job.rb
+++ b/app/jobs/release_form_job.rb
@@ -6,10 +6,12 @@ class ReleaseFormJob < ApplicationJob
   def perform(params, raw_post)
     @project = Project.find(params[:ApplicationId])
     if params[:GrantDecision] == 'Awarded' && !params[:ApprovedbyFinance]
-      @project.released_forms.create(payload: raw_post, form_type: :permission_to_start)
+      @project.released_forms.find_or_initialize_by(project: @project, form_type: :permission_to_start)
+          .update!(payload: raw_post, form_type: :permission_to_start)
     end
     if params[:ApprovedbyFinance]
-      @project.released_forms.create(payload: raw_post, form_type: :completion_report)
+      @project.released_forms.find_or_initialize_by(project: @project, form_type: :completion_report)
+          .update!(payload: raw_post, form_type: :completion_report)
     end
   end
 end


### PR DESCRIPTION
This fixes an edge case whereby if a user for example toggles the permission to start on and off this would have created multiple records. This changes to perform an upsert if there in an existing form of that type.