### PR TITLE
Refactored routes file and associated references

### DIFF
--- a/app/controllers/address_controller.rb
+++ b/app/controllers/address_controller.rb
@@ -28,7 +28,7 @@ class AddressController < ApplicationController
       if @type == "organisation"
         redirect_to organisation_mission_path(params['id'])
       elsif @type == "project"
-        redirect_to three_to_ten_k_project_description_get_path(params['id'])
+        redirect_to three_to_ten_k_project_description_path(params['id'])
       elsif @type == "user"
         redirect_to :authenticated_root
       end

--- a/app/controllers/project/accounts_controller.rb
+++ b/app/controllers/project/accounts_controller.rb
@@ -14,7 +14,7 @@ class Project::AccountsController < ApplicationController
       logger.info "Finished updating accounts_files for project ID: " \
                   "#{@project.id}"
 
-      redirect_to :three_to_ten_k_project_accounts_get
+      redirect_to :three_to_ten_k_project_accounts
 
     else
 

--- a/app/controllers/project/best_placed_controller.rb
+++ b/app/controllers/project/best_placed_controller.rb
@@ -2,8 +2,8 @@ class Project::BestPlacedController < ApplicationController
   include ProjectContext, ObjectErrorsLogger
 
   # This method updates the best_placed_description attribute of a project,
-  # redirecting to :three_to_ten_k_project_involvement_get if successful and
-  # re-rendering :show method if unsuccessful
+  # redirecting to :three_to_ten_k_project_how_will_your_project_involve_people
+  # if successful and re-rendering :show method if unsuccessful
   def update
 
     logger.info "Updating best_placed_description for project ID: " \
@@ -18,7 +18,7 @@ class Project::BestPlacedController < ApplicationController
       logger.info "Finished updating best_placed_description for project " \
                    "ID: #{@project.id}"
 
-      redirect_to :three_to_ten_k_project_involvement_get
+      redirect_to :three_to_ten_k_project_how_will_your_project_involve_people
 
     else
 

--- a/app/controllers/project/capital_works_controller.rb
+++ b/app/controllers/project/capital_works_controller.rb
@@ -9,8 +9,8 @@ class Project::CapitalWorksController < ApplicationController
   end
 
   # This method updates the capital_work and capital_work_file attributes of a
-  # project, redirecting to :three_to_ten_k_project_permission_get if successful
-  # and re-rendering :show method if unsuccessful
+  # project, redirecting to :three_to_ten_k_project_do_you_need_permission if
+  # successful and re-rendering :show method if unsuccessful
   def update
 
     logger.info "Updating capital_work for project ID: #{@project.id}"
@@ -28,9 +28,9 @@ class Project::CapitalWorksController < ApplicationController
       # capital work file - this is so that we can display the file back to
       # the user so they can check that they have uploaded the correct file
       if params[:project][:capital_work_file].present?
-        redirect_to :three_to_ten_k_project_capital_works_get
+        redirect_to :three_to_ten_k_project_capital_works
       else
-        redirect_to :three_to_ten_k_project_permission_get
+        redirect_to :three_to_ten_k_project_do_you_need_permission
       end
 
     else

--- a/app/controllers/project/cash_contributions_controller.rb
+++ b/app/controllers/project/cash_contributions_controller.rb
@@ -28,11 +28,11 @@ class Project::CashContributionsController < ApplicationController
 
       if @project.cash_contributions_question == "true"
 
-        redirect_to :three_to_ten_k_project_project_cash_contribution
+        redirect_to :three_to_ten_k_project_cash_contributions
 
       else
 
-        redirect_to :three_to_ten_k_project_grant_request_get
+        redirect_to :three_to_ten_k_project_your_grant_request
 
       end
 
@@ -65,7 +65,7 @@ class Project::CashContributionsController < ApplicationController
       logger.info "Successfully added cash contribution for project ID: " \
                   "#{@project.id}"
 
-      redirect_to :three_to_ten_k_project_project_cash_contribution
+      redirect_to :three_to_ten_k_project_cash_contributions
 
     else
 
@@ -81,7 +81,7 @@ class Project::CashContributionsController < ApplicationController
   end
 
   # This method deletes a project cash contribution, redirecting back to
-  # :three_to_ten_k_project_project_cash_contribution once completed.
+  # :three_to_ten_k_project_cash_contributions once completed.
   # If no cash contribution is found, then an ActiveRecord::RecordNotFound
   # exception is raised
   def delete
@@ -100,7 +100,7 @@ class Project::CashContributionsController < ApplicationController
     logger.info "Finished deleting cash contribution ID: " \
                 "#{cash_contribution.id}"
 
-    redirect_to :three_to_ten_k_project_project_cash_contribution
+    redirect_to :three_to_ten_k_project_cash_contributions
 
   end
 

--- a/app/controllers/project/check_answers_controller.rb
+++ b/app/controllers/project/check_answers_controller.rb
@@ -25,13 +25,13 @@ class Project::CheckAnswersController < ApplicationController
                     "individual private owner of heritage, redirecting to " \
                     "accounts page"
 
-        redirect_to :three_to_ten_k_project_accounts_get
+        redirect_to :three_to_ten_k_project_accounts
 
       else
 
         logger.info "Redirecting to governing documents page"
 
-        redirect_to :three_to_ten_k_project_governing_docs_get
+        redirect_to :three_to_ten_k_project_governing_documents
 
       end
 

--- a/app/controllers/project/costs_controller.rb
+++ b/app/controllers/project/costs_controller.rb
@@ -15,7 +15,7 @@ class Project::CostsController < ApplicationController
 
       logger.info "Costs found for project ID: #{@project.id}"
 
-      redirect_to :three_to_ten_k_project_cash_contributions_question_get
+      redirect_to :three_to_ten_k_project_are_you_getting_cash_contributions
 
     else
 
@@ -48,7 +48,7 @@ class Project::CostsController < ApplicationController
       logger.info "Succesfully added project cost for project ID: " \
                   "#{@project.id}"
 
-      redirect_to :three_to_ten_k_project_project_costs
+      redirect_to :three_to_ten_k_project_costs
 
     else
 
@@ -89,7 +89,7 @@ class Project::CostsController < ApplicationController
 
       logger.info "Finished deleting cost ID: #{cost.id}"
 
-      redirect_to :three_to_ten_k_project_project_costs
+      redirect_to :three_to_ten_k_project_costs
 
   end
 

--- a/app/controllers/project/dates_controller.rb
+++ b/app/controllers/project/dates_controller.rb
@@ -48,7 +48,7 @@ class Project::DatesController < ApplicationController
         logger.info "Successfully update start_date and end_date for project " \
                     "ID: #{@project.id}"
 
-        redirect_to :three_to_ten_k_project_location_get
+        redirect_to :three_to_ten_k_project_location
 
       end
 

--- a/app/controllers/project/declaration_controller.rb
+++ b/app/controllers/project/declaration_controller.rb
@@ -24,9 +24,9 @@ class Project::DeclarationController < ApplicationController
       # TODO: Remove bau flipper
       if Flipper.enabled?(:bau)
         ApplicationToSalesforceJob.perform_later(@project)
-        redirect_to :three_to_ten_k_project_application_submitted_get
+        redirect_to :three_to_ten_k_project_application_submitted
       else
-        redirect_to :three_to_ten_k_project_confirm_declaration_get
+        redirect_to :three_to_ten_k_project_confirm_declaration
       end
 
     else
@@ -66,7 +66,7 @@ class Project::DeclarationController < ApplicationController
       logger.info "Finished updating declaration attributes for project ID: " \
                    "#{@project.id}"
 
-      redirect_to :three_to_ten_k_project_confirm_declaration_get
+      redirect_to :three_to_ten_k_project_confirm_declaration
 
     else
 

--- a/app/controllers/project/description_controller.rb
+++ b/app/controllers/project/description_controller.rb
@@ -17,7 +17,7 @@ class Project::DescriptionController < ApplicationController
       logger.info "Finished updating project description for project ID: " \
                   " #{@project.id}"
 
-      redirect_to :three_to_ten_k_project_capital_works_get
+      redirect_to :three_to_ten_k_project_capital_works
 
     else
 

--- a/app/controllers/project/difference_controller.rb
+++ b/app/controllers/project/difference_controller.rb
@@ -2,8 +2,8 @@ class Project::DifferenceController < ApplicationController
   include ProjectContext, ObjectErrorsLogger
 
   # This method updates the difference attribute of a project, redirecting to
-  # :three_to_ten_k_project_matter_get if successful and re-rendering :show
-  # method if unsuccessful
+  # :three_to_ten_k_project_how_does_your_project_matter if successful and
+  # re-rendering :show method if unsuccessful
   def update
 
     logger.info "Updating difference for project ID: #{@project.id}"
@@ -16,7 +16,7 @@ class Project::DifferenceController < ApplicationController
 
       logger.info "Finished updating difference for project ID: #{@project.id}"
 
-      redirect_to :three_to_ten_k_project_matter_get
+      redirect_to :three_to_ten_k_project_how_does_your_project_matter
 
     else
 

--- a/app/controllers/project/evidence_of_support_controller.rb
+++ b/app/controllers/project/evidence_of_support_controller.rb
@@ -9,7 +9,7 @@ class Project::EvidenceOfSupportController < ApplicationController
   end
 
   # This method adds evidence of support to a project, redirecting back to
-  # :three_to_ten_k_project_project_support_evidence if successful and
+  # :three_to_ten_k_project_evidence_of_support if successful and
   # re-rendering :show method if unsuccessful
   def update
 
@@ -24,7 +24,7 @@ class Project::EvidenceOfSupportController < ApplicationController
       logger.info "Finished adding evidence of support for project ID: " \
                   "#{@project.id}"
 
-      redirect_to :three_to_ten_k_project_project_support_evidence
+      redirect_to :three_to_ten_k_project_evidence_of_support
 
     else
 
@@ -42,7 +42,7 @@ class Project::EvidenceOfSupportController < ApplicationController
   end
 
   # This method deletes evidence of support, redirecting back to
-  # :three_to_ten_k_project_project_support_evidence once completed
+  # :three_to_ten_k_project_evidence_of_support once completed
   def delete
 
     logger.info "User has selected to delete evidence_of_support ID: " \
@@ -59,7 +59,7 @@ class Project::EvidenceOfSupportController < ApplicationController
     logger.info "Finished deleting supporting evidence ID: " \
                 "#{evidence_of_support.id}"
 
-    redirect_to :three_to_ten_k_project_project_support_evidence
+    redirect_to :three_to_ten_k_project_evidence_of_support
 
   end
 

--- a/app/controllers/project/governing_documents_controller.rb
+++ b/app/controllers/project/governing_documents_controller.rb
@@ -15,7 +15,7 @@ class Project::GoverningDocumentsController < ApplicationController
       logger.info "Finished updating governing_document_file for project ID: " \
                   "#{@project.id}"
 
-      redirect_to :three_to_ten_k_project_governing_docs_get
+      redirect_to :three_to_ten_k_project_governing_documents
 
     else
 

--- a/app/controllers/project/heritage_controller.rb
+++ b/app/controllers/project/heritage_controller.rb
@@ -2,8 +2,8 @@ class Project::HeritageController < ApplicationController
   include ProjectContext, ObjectErrorsLogger
 
   # This method updates the heritage_description attribute of a project,
-  # redirecting to :three_to_ten_k_project_best_placed_get if successful and
-  # re-rendering :show method if unsuccessful
+  # redirecting to :three_to_ten_k_project_why_is_your_organisation_best_placed
+  # if successful and re-rendering :show method if unsuccessful
   def update
 
     logger.info "Updating heritage_description for project ID: #{@project.id}"
@@ -17,7 +17,7 @@ class Project::HeritageController < ApplicationController
       logger.debug "Finished updating heritage_description for project " \
                    "ID: #{@project.id}"
 
-      redirect_to :three_to_ten_k_project_best_placed_get
+      redirect_to :three_to_ten_k_project_why_is_your_organisation_best_placed
 
     else
 

--- a/app/controllers/project/involvement_controller.rb
+++ b/app/controllers/project/involvement_controller.rb
@@ -18,7 +18,7 @@ class Project::InvolvementController < ApplicationController
       logger.info "Finished updating project involvement_description for " \
                   "project ID: #{@project.id}"
 
-      redirect_to :three_to_ten_k_project_other_outcomes_get
+      redirect_to :three_to_ten_k_project_our_other_outcomes
 
     else
 

--- a/app/controllers/project/location_controller.rb
+++ b/app/controllers/project/location_controller.rb
@@ -19,7 +19,7 @@ class Project::LocationController < ApplicationController
 
         logger.debug "Finished updating location for project ID: #{@project.id}"
 
-        redirect_to :three_to_ten_k_project_description_get
+        redirect_to :three_to_ten_k_project_description
 
       else
 

--- a/app/controllers/project/matter_controller.rb
+++ b/app/controllers/project/matter_controller.rb
@@ -13,7 +13,7 @@ class Project::MatterController < ApplicationController
 
       logger.info "Finished updating matter for project ID: #{@project.id}"
 
-      redirect_to :three_to_ten_k_project_heritage_get
+      redirect_to :three_to_ten_k_project_your_project_heritage
 
     else
 

--- a/app/controllers/project/new_project_controller.rb
+++ b/app/controllers/project/new_project_controller.rb
@@ -2,7 +2,7 @@ class Project::NewProjectController < ApplicationController
   before_action :authenticate_user!
 
   # This method creates a new project and then redirects the
-  # to :three_to_ten_k_project_title_get
+  # to :three_to_ten_k_project_title
   def create_new_project
 
     logger.info "User ID: #{current_user.id} has selected to start a " \
@@ -14,7 +14,7 @@ class Project::NewProjectController < ApplicationController
     logger.info "Project created for user ID: #{current_user.id} with ID: " \
                 "#{@project.id}"
 
-    redirect_to three_to_ten_k_project_title_get_path(project_id: @project.id)
+    redirect_to three_to_ten_k_project_title_path(project_id: @project.id)
 
   end
 

--- a/app/controllers/project/non_cash_contributions_controller.rb
+++ b/app/controllers/project/non_cash_contributions_controller.rb
@@ -21,7 +21,7 @@ class Project::NonCashContributionsController < ApplicationController
 
       if @project.non_cash_contributions_question == "true"
 
-        redirect_to :three_to_ten_k_project_non_cash_contributions_get
+        redirect_to :three_to_ten_k_project_non_cash_contributions
 
       else
 
@@ -43,7 +43,7 @@ class Project::NonCashContributionsController < ApplicationController
   end
 
   # This method adds a non-cash contribution to a project, redirecting back to
-  # :three_to_ten_k_project_non_cash_contributions_get if successful and
+  # :three_to_ten_k_project_non_cash_contributions if successful and
   # re-rendering :show method if unsuccessful
   def update
 
@@ -62,7 +62,7 @@ class Project::NonCashContributionsController < ApplicationController
       logger.info "Successfully added non-cash contribution for project ID: " \
                   "#{@project.id}"
 
-      redirect_to :three_to_ten_k_project_non_cash_contributions_get
+      redirect_to :three_to_ten_k_project_non_cash_contributions
 
     else
 
@@ -84,7 +84,7 @@ class Project::NonCashContributionsController < ApplicationController
   end
 
   # This method deletes a project non-cash contribution, redirecting back to
-  # :three_to_ten_k_project_non_cash_contributions_get once completed.
+  # :three_to_ten_k_project_non_cash_contributions once completed.
   # If no non-cash contribution is found, then an ActiveRecord::RecordNotFound
   # exception is raised
   def delete
@@ -103,7 +103,7 @@ class Project::NonCashContributionsController < ApplicationController
     logger.debug "Finished deleting non-cash contribution ID: " \
                  "#{non_cash_contribution.id}"
 
-    redirect_to :three_to_ten_k_project_non_cash_contributions_get
+    redirect_to :three_to_ten_k_project_non_cash_contributions
 
   end
 

--- a/app/controllers/project/outcomes_controller.rb
+++ b/app/controllers/project/outcomes_controller.rb
@@ -16,7 +16,7 @@ class Project::OutcomesController < ApplicationController
       logger.info "Finished updating outcome attributes for project " \
                   "ID: #{@project.id}"
 
-      redirect_to :three_to_ten_k_project_project_costs
+      redirect_to :three_to_ten_k_project_costs
 
     else
 

--- a/app/controllers/project/permission_controller.rb
+++ b/app/controllers/project/permission_controller.rb
@@ -45,7 +45,7 @@ class Project::PermissionController < ApplicationController
       logger.info "Finished updating project permission attributes for " \
                   "project ID: #{@project.id}"
 
-      redirect_to :three_to_ten_k_project_difference_get
+      redirect_to :three_to_ten_k_project_difference
 
     else
 

--- a/app/controllers/project/title_controller.rb
+++ b/app/controllers/project/title_controller.rb
@@ -2,7 +2,7 @@ class Project::TitleController < ApplicationController
   include ProjectContext, ObjectErrorsLogger
 
   # This method updates the project_title attribute of a project,
-  # redirecting to :three_to_ten_k_project_dates_get if successful and
+  # redirecting to :three_to_ten_k_project_key_dates if successful and
   # re-rendering :show method if unsuccessful
   def update
 
@@ -17,7 +17,7 @@ class Project::TitleController < ApplicationController
       logger.info "Finished updating project_title for project ID: " \
                   "#{@project.id}"
 
-      redirect_to :three_to_ten_k_project_dates_get
+      redirect_to :three_to_ten_k_project_key_dates
 
     else
 

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -125,13 +125,13 @@ class SupportController < ApplicationController
 
         logger.info "Validation of POST /support form successful, redirecting user to /report-a-problem"
 
-        redirect_to :support_report_a_problem
+        redirect_to :report_a_problem
 
       elsif params[:support_type] == "ask_a_question"
 
         logger.info "Validation of POST /support form successful, redirecting user to /question-or-feedback"
 
-        redirect_to :support_question_or_feedback
+        redirect_to :question_or_feedback
 
       else
 

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -50,7 +50,7 @@
 
       <li class="nlhf-list__item">
 
-        <%= link_to_unless(project.submitted_on.present?, project.project_title.present? ? project.project_title : "Untitled project", three_to_ten_k_project_title_get_url(project_id: project.id), class: 'govuk-link govuk-link--no-visited-state') do |name|
+        <%= link_to_unless(project.submitted_on.present?, project.project_title.present? ? project.project_title : "Untitled project", three_to_ten_k_project_title_path(project_id: project.id), class: 'govuk-link govuk-link--no-visited-state') do |name|
           "#{name} - #{I18n.t("dashboard.submitted")}#{' - ' + I18n.t("dashboard.reference") + ': '  + project.project_reference_number if project.project_reference_number.present?}"
         end
         %>

--- a/app/views/partials/_phase-banner.html.erb
+++ b/app/views/partials/_phase-banner.html.erb
@@ -4,7 +4,7 @@
           beta
         </strong>
         <span class="govuk-phase-banner__text">
-          This is a new service, <%= link_to("your feedback", support_question_or_feedback_path, class: "govuk-link--no-visited-state") %> will help us to improve it.
+          This is a new service, <%= link_to("your feedback", question_or_feedback_path, class: "govuk-link--no-visited-state") %> will help us to improve it.
         </span>
       </p>
     </div>  

--- a/app/views/project/accounts/show.html.erb
+++ b/app/views/project/accounts/show.html.erb
@@ -20,7 +20,7 @@
 
 <%=
   form_with model: @project,
-            url: :three_to_ten_k_project_accounts_put,
+            url: :three_to_ten_k_project_accounts,
             method: :put,
             remote: no_js ? false : true do |f|
 %>
@@ -157,7 +157,7 @@
     render(
         ButtonComponent.new(
             element: "a",
-            href: three_to_ten_k_project_confirm_declaration_get_url
+            href: three_to_ten_k_project_confirm_declaration_url
         )
     )
   %>

--- a/app/views/project/best_placed/show.html.erb
+++ b/app/views/project/best_placed/show.html.erb
@@ -16,7 +16,7 @@
 
 <%=
   form_for @project,
-           url: :three_to_ten_k_project_best_placed_put,
+           url: :three_to_ten_k_project_why_is_your_organisation_best_placed,
            method: :put do |f|
 %>
 

--- a/app/views/project/capital_works/show.html.erb
+++ b/app/views/project/capital_works/show.html.erb
@@ -20,7 +20,7 @@
 
 <%=
   form_with model: @project,
-            url: :three_to_ten_k_project_capital_works_put,
+            url: :three_to_ten_k_project_capital_works,
             method: :put,
             remote: no_js ? false : true do |f|
 %>

--- a/app/views/project/cash_contributions/question.html.erb
+++ b/app/views/project/cash_contributions/question.html.erb
@@ -16,7 +16,7 @@
 
 <%=
   form_for @project,
-           url: :three_to_ten_k_project_cash_contributions_question_put,
+           url: :three_to_ten_k_project_are_you_getting_cash_contributions,
            method: :put do |f|
 %>
 

--- a/app/views/project/cash_contributions/show.html.erb
+++ b/app/views/project/cash_contributions/show.html.erb
@@ -192,7 +192,7 @@
 
 <%=
   form_with model: @project,
-            url: :three_to_ten_k_project_project_cash_contribution,
+            url: :three_to_ten_k_project_cash_contributions,
             method: :put,
             remote: no_js ? false : true do |f|
 %>
@@ -521,7 +521,7 @@
 
 <hr class="govuk-section-break--l govuk-section-break--visible">
 
-<form action="<%= three_to_ten_k_project_grant_request_get_url %>"
+<form action="<%= three_to_ten_k_project_your_grant_request_url %>"
       method="get">
 
   <p class="govuk-body">

--- a/app/views/project/check_answers/_best_placed.html.erb
+++ b/app/views/project/check_answers/_best_placed.html.erb
@@ -10,7 +10,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_best_placed_get_path,
+                 link_url: three_to_ten_k_project_why_is_your_organisation_best_placed_path,
                  link_hidden_label: t('views.project.check_your_answers.best_placed')
              }
   %>

--- a/app/views/project/check_answers/_capital_work.html.erb
+++ b/app/views/project/check_answers/_capital_work.html.erb
@@ -22,7 +22,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_capital_works_get_path,
+                 link_url: three_to_ten_k_project_capital_works_path,
                  link_hidden_label: t('views.project.check_your_answers.capital_work')
              }
   %>

--- a/app/views/project/check_answers/_cash_contributions.html.erb
+++ b/app/views/project/check_answers/_cash_contributions.html.erb
@@ -61,7 +61,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_project_cash_contribution_path,
+                 link_url: three_to_ten_k_project_cash_contributions_path,
                  link_hidden_label: t('views.project.check_your_answers.cash_contributions')
              }
   %>

--- a/app/views/project/check_answers/_community_matters.html.erb
+++ b/app/views/project/check_answers/_community_matters.html.erb
@@ -10,7 +10,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_matter_get_path,
+                 link_url: three_to_ten_k_project_how_does_your_project_matter_path,
                  link_hidden_label: t('views.project.check_your_answers.community_matters')
              }
   %>

--- a/app/views/project/check_answers/_costs.html.erb
+++ b/app/views/project/check_answers/_costs.html.erb
@@ -42,7 +42,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_project_costs_path,
+                 link_url: three_to_ten_k_project_costs_path,
                  link_hidden_label: t('views.project.check_your_answers.project_cost'),
                  anchor_id: "project_project_costs"
              }

--- a/app/views/project/check_answers/_description.html.erb
+++ b/app/views/project/check_answers/_description.html.erb
@@ -10,7 +10,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_description_get_path,
+                 link_url: three_to_ten_k_project_description_path,
                  link_hidden_label: t('views.project.check_your_answers.description'),
                  anchor_id: "project_description"
              }

--- a/app/views/project/check_answers/_difference.html.erb
+++ b/app/views/project/check_answers/_difference.html.erb
@@ -10,7 +10,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_difference_get_path,
+                 link_url: three_to_ten_k_project_difference_path,
                  link_hidden_label: t('views.project.check_your_answers.difference')
              }
   %>

--- a/app/views/project/check_answers/_end_date.html.erb
+++ b/app/views/project/check_answers/_end_date.html.erb
@@ -10,7 +10,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_dates_get_path,
+                 link_url: three_to_ten_k_project_key_dates_path,
                  link_hidden_label: t('views.project.check_your_answers.project_end_date')
              }
   %>

--- a/app/views/project/check_answers/_evidence_of_support.html.erb
+++ b/app/views/project/check_answers/_evidence_of_support.html.erb
@@ -44,7 +44,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_project_support_evidence_path,
+                 link_url: three_to_ten_k_project_evidence_of_support_path,
                  link_hidden_label: t('views.project.check_your_answers.evidence_of_support')
              }
   %>

--- a/app/views/project/check_answers/_heritage.html.erb
+++ b/app/views/project/check_answers/_heritage.html.erb
@@ -8,7 +8,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_heritage_get_path,
+                 link_url: three_to_ten_k_project_your_project_heritage_path,
                  link_hidden_label: t('views.project.check_your_answers.heritage')
              }
   %>

--- a/app/views/project/check_answers/_involvement.html.erb
+++ b/app/views/project/check_answers/_involvement.html.erb
@@ -10,7 +10,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_involvement_get_path,
+                 link_url: three_to_ten_k_project_how_will_your_project_involve_people_path,
                  link_hidden_label: t('views.project.check_your_answers.involvement'),
                  anchor_id: "project_involvement_description"
              }

--- a/app/views/project/check_answers/_location.html.erb
+++ b/app/views/project/check_answers/_location.html.erb
@@ -40,7 +40,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_location_get_path,
+                 link_url: three_to_ten_k_project_location_path,
                  link_hidden_label: t('views.project.check_your_answers.where_is_your_project_taking_place')
              }
   %>

--- a/app/views/project/check_answers/_non_cash_contributions.html.erb
+++ b/app/views/project/check_answers/_non_cash_contributions.html.erb
@@ -39,7 +39,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_non_cash_contributions_get_path,
+                 link_url: three_to_ten_k_project_non_cash_contributions_path,
                  link_hidden_label: t('views.project.check_your_answers.non_cash_contributions')
              }
   %>

--- a/app/views/project/check_answers/_other_outcomes.html.erb
+++ b/app/views/project/check_answers/_other_outcomes.html.erb
@@ -30,7 +30,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_other_outcomes_get_path,
+                 link_url: three_to_ten_k_project_our_other_outcomes_path,
                  link_hidden_label: t('views.project.check_your_answers.other_outcomes')
              }
   %>

--- a/app/views/project/check_answers/_permission.html.erb
+++ b/app/views/project/check_answers/_permission.html.erb
@@ -26,7 +26,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_permission_get_path,
+                 link_url: three_to_ten_k_project_do_you_need_permission_path,
                  link_hidden_label: t('views.project.check_your_answers.permission')
              }
   %>
@@ -47,7 +47,7 @@
 
     <%= render partial: 'project/check_answers/change_link',
                locals: {
-                   link_url: three_to_ten_k_project_permission_get_path,
+                   link_url: three_to_ten_k_project_do_you_need_permission_path,
                    link_hidden_label: t('views.project.check_your_answers.permission')
                }
     %>

--- a/app/views/project/check_answers/_start_date.html.erb
+++ b/app/views/project/check_answers/_start_date.html.erb
@@ -10,7 +10,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_dates_get_path,
+                 link_url: three_to_ten_k_project_key_dates_path,
                  link_hidden_label: t('views.project.check_your_answers.project_start_date')
              }
   %>

--- a/app/views/project/check_answers/_title.html.erb
+++ b/app/views/project/check_answers/_title.html.erb
@@ -10,7 +10,7 @@
 
   <%= render partial: 'project/check_answers/change_link',
              locals: {
-                 link_url: three_to_ten_k_project_title_get_path,
+                 link_url: three_to_ten_k_project_title_path,
                  link_hidden_label: t('views.project.check_your_answers.project_title')
              }
   %>

--- a/app/views/project/check_answers/show.html.erb
+++ b/app/views/project/check_answers/show.html.erb
@@ -41,7 +41,7 @@
 
 <%=
   form_with model: @project,
-            url: :three_to_ten_k_project_check_answers_update,
+            url: :three_to_ten_k_project_check_your_answers,
             method: :put,
             local: true do |f|
 %>

--- a/app/views/project/costs/show.html.erb
+++ b/app/views/project/costs/show.html.erb
@@ -193,7 +193,7 @@
 
 <%=
   form_with model: @project,
-            url: :three_to_ten_k_project_project_costs,
+            url: :three_to_ten_k_project_costs,
             class: "govuk-!-margin-bottom-3",
             method: :put, local: true do |f|
 %>
@@ -514,7 +514,7 @@
 <p class="govuk-body">If you have finished adding all your costs</p>
 
 <%=
-  form_with url: :three_to_ten_k_project_project_costs_validate_and_redirect,
+  form_with url: :three_to_ten_k_project_confirm_costs,
             method: :put, local: true do
 %>
 

--- a/app/views/project/dates/show.html.erb
+++ b/app/views/project/dates/show.html.erb
@@ -16,7 +16,7 @@
 
 <%=
   form_for @project,
-           url: :three_to_ten_k_project_dates_put,
+           url: :three_to_ten_k_project_key_dates,
            method: :put do |f|
 %>
 

--- a/app/views/project/declaration/show_confirm_declaration.html.erb
+++ b/app/views/project/declaration/show_confirm_declaration.html.erb
@@ -16,7 +16,7 @@
 
 <%=
   form_for @project,
-           url: :three_to_ten_k_project_confirm_declaration_put,
+           url: :three_to_ten_k_project_confirm_declaration,
            method: :put do |f|
 %>
 
@@ -94,7 +94,7 @@
 
         <%=
           f.label :confirm_declaration,
-                    "I have read and agreed with the #{link_to 'declaration', :three_to_ten_k_project_declaration_get}".html_safe,
+                    "I have read and agreed with the #{link_to 'declaration', :three_to_ten_k_project_declaration}".html_safe,
                     class: "govuk-label govuk-checkboxes__label"
         %>
 

--- a/app/views/project/declaration/show_declaration.html.erb
+++ b/app/views/project/declaration/show_declaration.html.erb
@@ -16,7 +16,7 @@
 
 <%=
   form_for @project,
-           url: :three_to_ten_k_project_declaration_put,
+           url: :three_to_ten_k_project_declaration,
            method: :put,
            local: true do |f|
 %>

--- a/app/views/project/description/show.html.erb
+++ b/app/views/project/description/show.html.erb
@@ -15,7 +15,7 @@
 
 <%=
   form_for @project,
-           url: :three_to_ten_k_project_description_put,
+           url: :three_to_ten_k_project_description,
            method: :put do |f|
 %>
 

--- a/app/views/project/difference/show.html.erb
+++ b/app/views/project/difference/show.html.erb
@@ -16,7 +16,7 @@
 
 <%=
   form_for @project,
-           url: :three_to_ten_k_project_difference_put,
+           url: :three_to_ten_k_project_difference,
            method: :put do |f|
 %>
 

--- a/app/views/project/evidence_of_support/show.html.erb
+++ b/app/views/project/evidence_of_support/show.html.erb
@@ -101,7 +101,7 @@
             <td class="govuk-table__cell">
               <%=
                 form_with model: @project,
-                          url: three_to_ten_k_project_supporting_evidence_delete_path(supporting_evidence_id: eos.id),
+                          url: three_to_ten_k_project_evidence_of_support_delete_path(supporting_evidence_id: eos.id),
                           method: :delete,
                           local: true do |f|
               %>
@@ -132,7 +132,7 @@
 
 <%=
   form_with model: @project,
-            url: :three_to_ten_k_project_project_support_evidence,
+            url: :three_to_ten_k_project_evidence_of_support,
             method: :put,
             remote: no_js ? false : true do |f|
 %>
@@ -285,7 +285,7 @@
   render(
       ButtonComponent.new(
           element: "a",
-          href: three_to_ten_k_project_check_answers_get_url
+          href: three_to_ten_k_project_check_your_answers_url
       )
   )
 %>

--- a/app/views/project/governing_documents/show.html.erb
+++ b/app/views/project/governing_documents/show.html.erb
@@ -20,7 +20,7 @@
 
 <%=
   form_with model: @project,
-            url: :three_to_ten_k_project_governing_docs_put,
+            url: :three_to_ten_k_project_governing_documents,
             method: :put,
             remote: no_js ? false : true do |f|
 %>
@@ -175,7 +175,7 @@
     render(
         ButtonComponent.new(
             element: "a",
-            href: three_to_ten_k_project_accounts_get_url
+            href: three_to_ten_k_project_accounts_url
         )
     )
   %>

--- a/app/views/project/grant_request/show.html.erb
+++ b/app/views/project/grant_request/show.html.erb
@@ -147,7 +147,7 @@
     render(
         ButtonComponent.new(
             element: "a",
-            href: three_to_ten_k_project_non_cash_contributions_get_url
+            href: three_to_ten_k_project_non_cash_contributions_path
         )
     )
   %>

--- a/app/views/project/heritage/show.html.erb
+++ b/app/views/project/heritage/show.html.erb
@@ -16,7 +16,7 @@
 
 <%=
   form_for @project,
-           url: :three_to_ten_k_project_heritage_put,
+           url: :three_to_ten_k_project_your_project_heritage,
            method: :put do |f|
 %>
 

--- a/app/views/project/involvement/show.html.erb
+++ b/app/views/project/involvement/show.html.erb
@@ -16,7 +16,7 @@
 
 <%=
   form_for @project,
-           url: :three_to_ten_k_project_involvement_put,
+           url: :three_to_ten_k_project_how_will_your_project_involve_people,
            method: :put do |f|
 %>
 

--- a/app/views/project/location/show.html.erb
+++ b/app/views/project/location/show.html.erb
@@ -11,7 +11,7 @@
     first_form_element: :project_same_location_yes
 } if @project.errors.any? %>
 
-<%= form_for @project, url: three_to_ten_k_project_location_put_path, method: :put do |f| %>
+<%= form_for @project, url: :three_to_ten_k_project_location, method: :put do |f| %>
 
   <div class="govuk-form-group <%= "govuk-form-group--error" if @project.errors.any? %>">
 

--- a/app/views/project/matter/show.html.erb
+++ b/app/views/project/matter/show.html.erb
@@ -16,7 +16,7 @@
 
 <%=
   form_for @project,
-           url: :three_to_ten_k_project_matter_put,
+           url: :three_to_ten_k_project_how_does_your_project_matter,
            method: :put do |f|
 %>
 

--- a/app/views/project/non_cash_contributions/question.html.erb
+++ b/app/views/project/non_cash_contributions/question.html.erb
@@ -17,7 +17,7 @@
 
 <%=
   form_for @project,
-           url: :three_to_ten_k_project_non_cash_contributions_question_put,
+           url: :three_to_ten_k_project_are_you_getting_non_cash_contributions,
            method: :put do |f|
 %>
 

--- a/app/views/project/non_cash_contributions/show.html.erb
+++ b/app/views/project/non_cash_contributions/show.html.erb
@@ -154,7 +154,7 @@
 
 <%=
   form_with model: @project,
-            url: :three_to_ten_k_project_non_cash_contributions_put,
+            url: :three_to_ten_k_project_non_cash_contributions,
             method: :put,
             local: true do |f|
 %>

--- a/app/views/project/outcomes/show.html.erb
+++ b/app/views/project/outcomes/show.html.erb
@@ -16,7 +16,7 @@
 
 <%=
   form_for @project,
-           url: :three_to_ten_k_project_other_outcomes_put,
+           url: :three_to_ten_k_project_our_other_outcomes,
            method: :put do |f|
 %>
 

--- a/app/views/project/permission/show.html.erb
+++ b/app/views/project/permission/show.html.erb
@@ -16,7 +16,7 @@
 
 <%=
   form_for @project,
-           url: :three_to_ten_k_project_permission_put,
+           url: :three_to_ten_k_project_do_you_need_permission,
            method: :put do |f|
 %>
 

--- a/app/views/project/title/show.html.erb
+++ b/app/views/project/title/show.html.erb
@@ -11,7 +11,7 @@
     first_form_element: :project_project_title
 } if @project.errors.any? %>
 
-<%= form_for @project, url: three_to_ten_k_project_title_put_path, method: :put do |f| %>
+<%= form_for @project, url: :three_to_ten_k_project_title, method: :put do |f| %>
 
   <div class="govuk-form-group">
 

--- a/app/views/project/volunteers/show.html.erb
+++ b/app/views/project/volunteers/show.html.erb
@@ -260,7 +260,7 @@
   <% end %>
 <% end %>
 
-<form action="<%= three_to_ten_k_project_project_support_evidence_path %>"
+<form action="<%= three_to_ten_k_project_evidence_of_support_path %>"
       method="get">
   <p class="govuk-body">If you have finished adding volunteers</p>
   <%= render(ButtonComponent.new(element: "input")) %>

--- a/app/views/support/question_or_feedback.html.erb
+++ b/app/views/support/question_or_feedback.html.erb
@@ -18,7 +18,7 @@
   </div>
 <% end %>
 
-<%= form_tag :support_question_or_feedback, local: true do %>
+<%= form_tag :question_or_feedback, local: true do %>
 
   <div class="govuk-form-group">
 

--- a/app/views/support/report_a_problem.html.erb
+++ b/app/views/support/report_a_problem.html.erb
@@ -18,7 +18,7 @@
   </div>
 <% end %>
 
-<%= form_tag :support_report_a_problem, local: true do %>
+<%= form_tag :report_a_problem, local: true do %>
 
   <div class="govuk-form-group">
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  # Devise root scope - used to determine the authenticated
+  # and unauthenticated root pages
   devise_scope :user do
     unauthenticated do
       root to: "devise/sessions#new"
@@ -9,17 +11,41 @@ Rails.application.routes.draw do
     end
   end
 
+  # TODO: Remove bau flipper
+  constraints lambda { !Flipper.enabled?(:bau) } do
+    devise_scope :user do
+      get "/users/sign_up",  :to => "devise/sessions#new"
+    end
+  end
+
+  # Override the Devise registration controller, which allows us
+  # to create an organisation when a user is created
+  devise_for :users,
+             :controllers  => {
+                 :registrations => 'user/registrations'
+             }
+
+  # Account section of the service
   namespace :account do
     get 'create-new-account', to: 'account#new'
     get 'account-created', to: 'account#account_created'
   end
 
+  # User section of the service
   namespace :user do
     get 'details', to: 'details#show'
     put 'details', to: 'details#update'
-
   end
 
+  # Dashboard section of the service
+  # TODO: Remove bau flipper
+  get 'start-a-project', to: 'home#show',
+      constraints: lambda { Flipper.enabled?(:bau) }
+  get 'start-a-project', to: 'dashboard#show',
+      constraints: lambda { !Flipper.enabled?(:bau) }
+
+  # Modular address section of the service
+  # Used in /user, /organisation and /3-10k/project
   scope '/:type/:id/address' do
     get '/postcode', to: 'address#postcode_lookup'
     post '/address-results',
@@ -30,22 +56,23 @@ Rails.application.routes.draw do
         to: 'address#show'
     put '/address',
         to: 'address#update'
-    # This route ensures that attempting to navigate back to the list of address results
-    # redirects the user back to the search page
+    # This route ensures that attempting to navigate back to the list of
+    # address results redirects the user back to the search page
     get '/address-results',
         to: 'address#postcode_lookup'
-    # This route ensures that users can navigate back to the address details page
+    # This route ensures that users can navigate back to the address details
+    # page
     get '/address-details',
         to: 'address#show'
   end
 
+  # Organisation section of the service
   namespace :organisation do
     scope '/:organisation_id' do
       get '/type', to: 'type#show'
       put '/type', to: 'type#update'
       get '/numbers', to: 'numbers#show'
       put '/numbers', to: 'numbers#update'
-
       get '/mission', to: 'mission#show'
       put '/mission', to: 'mission#update'
       get '/signatories', to: 'signatories#show'
@@ -54,195 +81,109 @@ Rails.application.routes.draw do
     end
   end
 
+  # Project section of the service (for small grants)
   scope "/3-10k", as: :three_to_ten_k do
     namespace :project do
 
+      # Not scoped under /:project_id, as the project does not yet exist
       get 'create-new-project', to: 'new_project#create_new_project', as: :create
 
-      get ':project_id/title', to: 'title#show', as: :title_get
-      put ':project_id/title', to: 'title#update', as: :title_put
-
-      get ':project_id/key-dates', to: 'dates#show', as: :dates_get
-      put ':project_id/key-dates', to: 'dates#update', as: :dates_put
-
-      get ':project_id/location', to: 'location#show', as: :location_get
-      put ':project_id/location', to: 'location#update', as: :location_put
-
-      get ':project_id/description', to: 'description#show', as: :description_get
-      put ':project_id/description', to: 'description#update', as: :description_put
-
-      get ':project_id/capital-works',
-          to: 'capital_works#show',
-          as: :capital_works_get
-      put ':project_id/capital-works',
-          to: 'capital_works#update',
-          as: :capital_works_put
-
-      get ':project_id/do-you-need-permission',
-          to: 'permission#show',
-          as: :permission_get
-      put ':project_id/do-you-need-permission',
-          to: 'permission#update',
-          as: :permission_put
-
-      get ':project_id/difference', to: 'difference#show', as: :difference_get
-      put ':project_id/difference', to: 'difference#update', as: :difference_put
-
-      get ':project_id/how-does-your-project-matter', to: 'matter#show', as: :matter_get
-      put ':project_id/how-does-your-project-matter', to: 'matter#update', as: :matter_put
-
-      get ':project_id/your-project-heritage', to: 'heritage#show', as: :heritage_get
-      put ':project_id/your-project-heritage', to: 'heritage#update', as: :heritage_put
-
-      get ':project_id/why-is-your-organisation-best-placed',
-          to: 'best_placed#show', as: :best_placed_get
-      put ':project_id/why-is-your-organisation-best-placed',
-          to: 'best_placed#update', as: :best_placed_put
-
-      get ':project_id/how-will-your-project-involve-people',
-          to: 'involvement#show', as: :involvement_get
-      put ':project_id/how-will-your-project-involve-people',
-          to: 'involvement#update', as: :involvement_put
-
-      get ':project_id/our-other-outcomes',
-          to: 'outcomes#show',
-          as: :other_outcomes_get
-      put ':project_id/our-other-outcomes',
-          to: 'outcomes#update',
-          as: :other_outcomes_put
-
-      get ':project_id/costs', to: 'costs#show', as: :project_costs
-      put ':project_id/costs', to: 'costs#update'
-      delete ':project_id/costs/:project_cost_id',
-             to: 'costs#delete',
-             as: :cost_delete
-
-      put ':project_id/confirm-costs',
-          to: 'costs#validate_and_redirect',
-          as: :project_costs_validate_and_redirect
-
-      get ':project_id/are-you-getting-cash-contributions',
-          to: 'cash_contributions#question',
-          as: :cash_contributions_question_get
-      put ':project_id/are-you-getting-cash-contributions',
-          to: 'cash_contributions#question_update',
-          as: :cash_contributions_question_put
-
-      get ':project_id/cash-contributions',
-          to: 'cash_contributions#show',
-          as: :project_cash_contribution
-      put ':project_id/cash-contributions',
-          to: 'cash_contributions#update'
-      delete ':project_id/cash-contributions/:cash_contribution_id',
-             to: 'cash_contributions#delete',
-             as: :cash_contribution_delete
-
-      get ':project_id/your-grant-request',
-          to: 'grant_request#show',
-          as: :grant_request_get
-
-      get ':project_id/are-you-getting-non-cash-contributions',
-          to: 'non_cash_contributions#question',
-          as: :non_cash_contributions_question_get
-      put ':project_id/are-you-getting-non-cash-contributions',
-          to: 'non_cash_contributions#question_update',
-          as: :non_cash_contributions_question_put
-
-      get ':project_id/non-cash-contributions',
-          to: 'non_cash_contributions#show',
-          as: :non_cash_contributions_get
-      put ':project_id/non-cash-contributions',
-          to: 'non_cash_contributions#update',
-          as: :non_cash_contributions_put
-      delete ':project_id/non-cash-contributions/:non_cash_contribution_id',
-             to: 'non_cash_contributions#delete',
-             as: :non_cash_contribution_delete
-
-      get ':project_id/volunteers', to: 'volunteers#show', as: :volunteers
-      put ':project_id/volunteers', to: 'volunteers#update'
-      delete ':project_id/volunteers/:volunteer_id',
-             to: 'volunteers#delete',
-             as: :volunteer_delete
-
-      get ':project_id/evidence-of-support',
-          to: 'evidence_of_support#show',
-          as: :project_support_evidence
-      put ':project_id/evidence-of-support',
-          to: 'evidence_of_support#update'
-      delete ':project_id/evidence-of-support/:supporting_evidence_id',
-             to: 'evidence_of_support#delete',
-             as: :supporting_evidence_delete
-
-      get ':project_id/check-your-answers',
-          to: 'check_answers#show', as: :check_answers_get
-      put ':project_id/check-your-answers',
-          to: 'check_answers#update', as: :check_answers_update
-
-      get ':project_id/declaration', to: 'declaration#show_declaration', as: :declaration_get
-      put ':project_id/declaration', to: 'declaration#update_declaration', as: :declaration_put
-
-      get ':project_id/confirm-declaration',
-          to: 'declaration#show_confirm_declaration',
-          as: :confirm_declaration_get
-      put ':project_id/confirm-declaration',
-          to: 'declaration#update_confirm_declaration',
-          as: :confirm_declaration_put
-
-      get ':project_id/application-submitted',
-          to: 'application_submitted#show',
-          as: :application_submitted_get
-
-      get 'location' => 'project_location#project_location'
-      get ':project_id/governing-documents',
-          to: 'governing_documents#show',
-          as: :governing_docs_get
-      put ':project_id/governing-documents',
-          to: 'governing_documents#update',
-          as: :governing_docs_put
-
-      get ':project_id/accounts', to: 'accounts#show', as: :accounts_get
-      put ':project_id/accounts', to: 'accounts#update', as: :accounts_put
+      scope '/:project_id' do
+        get 'title', to: 'title#show'
+        put 'title', to: 'title#update'
+        get 'key-dates', to: 'dates#show'
+        put 'key-dates', to: 'dates#update'
+        get 'location', to: 'location#show'
+        put 'location', to: 'location#update'
+        get 'description', to: 'description#show'
+        put 'description', to: 'description#update'
+        get 'capital-works', to: 'capital_works#show'
+        put 'capital-works', to: 'capital_works#update'
+        get 'do-you-need-permission', to: 'permission#show'
+        put 'do-you-need-permission', to: 'permission#update'
+        get 'difference', to: 'difference#show'
+        put 'difference', to: 'difference#update'
+        get 'how-does-your-project-matter', to: 'matter#show'
+        put 'how-does-your-project-matter', to: 'matter#update'
+        get 'your-project-heritage', to: 'heritage#show'
+        put 'your-project-heritage', to: 'heritage#update'
+        get 'why-is-your-organisation-best-placed', to: 'best_placed#show'
+        put 'why-is-your-organisation-best-placed', to: 'best_placed#update'
+        get 'how-will-your-project-involve-people', to: 'involvement#show'
+        put 'how-will-your-project-involve-people', to: 'involvement#update'
+        get 'our-other-outcomes', to: 'outcomes#show'
+        put 'our-other-outcomes', to: 'outcomes#update'
+        get 'costs', to: 'costs#show'
+        put 'costs', to: 'costs#update'
+        delete 'costs/:project_cost_id', to: 'costs#delete', as: :cost_delete
+        put 'confirm-costs', to: 'costs#validate_and_redirect'
+        get 'are-you-getting-cash-contributions',
+            to: 'cash_contributions#question'
+        put 'are-you-getting-cash-contributions',
+            to: 'cash_contributions#question_update'
+        get 'cash-contributions', to: 'cash_contributions#show'
+        put 'cash-contributions', to: 'cash_contributions#update'
+        delete 'cash-contributions/:cash_contribution_id',
+               to: 'cash_contributions#delete',
+               as: :cash_contribution_delete
+        get 'your-grant-request', to: 'grant_request#show'
+        get 'are-you-getting-non-cash-contributions',
+            to: 'non_cash_contributions#question'
+        put 'are-you-getting-non-cash-contributions',
+            to: 'non_cash_contributions#question_update'
+        get 'non-cash-contributions', to: 'non_cash_contributions#show'
+        put 'non-cash-contributions', to: 'non_cash_contributions#update'
+        delete 'non-cash-contributions/:non_cash_contribution_id',
+               to: 'non_cash_contributions#delete',
+               as: :non_cash_contribution_delete
+        get 'volunteers', to: 'volunteers#show'
+        put 'volunteers', to: 'volunteers#update'
+        delete 'volunteers/:volunteer_id', to: 'volunteers#delete',
+               as: :volunteer_delete
+        get 'evidence-of-support', to: 'evidence_of_support#show'
+        put 'evidence-of-support', to: 'evidence_of_support#update'
+        delete 'evidence-of-support/:supporting_evidence_id',
+               to: 'evidence_of_support#delete',
+               as: :evidence_of_support_delete
+        get 'check-your-answers', to: 'check_answers#show'
+        put 'check-your-answers', to: 'check_answers#update'
+        get 'governing-documents', to: 'governing_documents#show'
+        put 'governing-documents', to: 'governing_documents#update'
+        get 'accounts', to: 'accounts#show'
+        put 'accounts', to: 'accounts#update'
+        get 'confirm-declaration', to: 'declaration#show_confirm_declaration'
+        put 'confirm-declaration', to: 'declaration#update_confirm_declaration'
+        get 'declaration', to: 'declaration#show_declaration'
+        put 'declaration', to: 'declaration#update_declaration'
+        get 'application-submitted', to: 'application_submitted#show'
+      end
 
     end
-
   end
 
-  get '/accessibility-statement',
-      to: 'static_pages#show_accessibility_statement',
-      as: :accessibility_statement
+  # Static pages within the service
+  get '/accessibility-statement', to: 'static_pages#show_accessibility_statement'
 
-  get 'health' => 'health#get_status'
-
+  # Support section of the service
   get 'support', to: 'support#show'
   post 'support', to: 'support#update'
-  get 'support/report-a-problem', to: 'support#report_a_problem'
-  post 'support/report-a-problem', to: 'support#process_problem'
-  get 'support/question-or-feedback', to: 'support#question_or_feedback'
-  post 'support/question-or-feedback', to: 'support#process_question'
-
-  # TODO: Remove bau flipper
-  constraints lambda { !Flipper.enabled?(:bau) } do
-    devise_scope :user do
-      get "/users/sign_up",  :to => "devise/sessions#new"
-    end
+  scope '/support' do
+    # We use a scope here, as there is no related Support object
+    get 'report-a-problem', to: 'support#report_a_problem'
+    post 'report-a-problem', to: 'support#process_problem'
+    get 'question-or-feedback', to: 'support#question_or_feedback'
+    post 'question-or-feedback', to: 'support#process_question'
   end
 
-  # Override the Devise registration controller
-  devise_for :users,
-             :controllers  => {
-                 :registrations => 'user/registrations'
-             }
-
-  # TODO: Remove bau flipper
-  get 'start-a-project', to: 'home#show', constraints: lambda { Flipper.enabled?(:bau) }
-  get 'start-a-project', to: 'dashboard#show', constraints: lambda { !Flipper.enabled?(:bau) }
-
+  # Endpoint for released forms webhook
   post 'consumer' => 'released_form#receive' do
     header "Content-Type", "application/json"
   end
-  resources :organisation do
-    get 'show'
-  end
-  # TODO Put this behind auth on PAAS
+
+  # Health check route for GOV.UK PaaS
+  get 'health' => 'health#get_status'
+
+  # DelayedJob dashboard
   match "/delayed_job" => DelayedJobWeb, :anchor => false, :via => [:get, :post]
+
 end

--- a/spec/controllers/project/accounts_controller_spec.rb
+++ b/spec/controllers/project/accounts_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Project::AccountsController do
           }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_accounts_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_accounts)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(project.accounts_files.present?).to eq(true)
@@ -111,7 +111,7 @@ RSpec.describe Project::AccountsController do
           }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_accounts_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_accounts)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(project.accounts_files.present?).to eq(true)

--- a/spec/controllers/project/best_placed_controller_spec.rb
+++ b/spec/controllers/project/best_placed_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Project::BestPlacedController do
           params: { project_id: project.id }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_involvement_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_how_will_your_project_involve_people)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -46,7 +46,7 @@ RSpec.describe Project::BestPlacedController do
           }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_involvement_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_how_will_your_project_involve_people)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -85,7 +85,7 @@ RSpec.describe Project::BestPlacedController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_involvement_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_how_will_your_project_involve_people)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).best_placed_description).to eq("Test")

--- a/spec/controllers/project/capital_works_controller_spec.rb
+++ b/spec/controllers/project/capital_works_controller_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Project::CapitalWorksController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_permission_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_do_you_need_permission)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).capital_work).to eq(true)
@@ -115,7 +115,7 @@ RSpec.describe Project::CapitalWorksController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_capital_works_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_capital_works)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).capital_work).to eq(true)

--- a/spec/controllers/project/cash_contributions_controller_spec.rb
+++ b/spec/controllers/project/cash_contributions_controller_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Project::CashContributionsController do
           }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_grant_request_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_your_grant_request)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -124,7 +124,7 @@ RSpec.describe Project::CashContributionsController do
 
       expect(response).to have_http_status(:redirect)
       expect(response)
-          .to redirect_to(:three_to_ten_k_project_project_cash_contribution)
+          .to redirect_to(:three_to_ten_k_project_cash_contributions)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -354,7 +354,7 @@ RSpec.describe Project::CashContributionsController do
 
       expect(response).to have_http_status(:redirect)
       expect(response)
-          .to redirect_to(:three_to_ten_k_project_project_cash_contribution)
+          .to redirect_to(:three_to_ten_k_project_cash_contributions)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).cash_contributions.first.errors.empty?)
@@ -390,7 +390,7 @@ RSpec.describe Project::CashContributionsController do
 
       expect(response).to have_http_status(:redirect)
       expect(response)
-          .to redirect_to(:three_to_ten_k_project_project_cash_contribution)
+          .to redirect_to(:three_to_ten_k_project_cash_contributions)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).cash_contributions.first.errors.empty?)
@@ -463,7 +463,7 @@ RSpec.describe Project::CashContributionsController do
 
       expect(response).to have_http_status(:redirect)
       expect(response)
-          .to redirect_to(:three_to_ten_k_project_project_cash_contribution)
+          .to redirect_to(:three_to_ten_k_project_cash_contributions)
 
     end
 

--- a/spec/controllers/project/check_answers_controller_spec.rb
+++ b/spec/controllers/project/check_answers_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Project::CheckAnswersController do
 
       expect(response).to have_http_status(:redirect)
       expect(response)
-          .to redirect_to(:three_to_ten_k_project_accounts_get)
+          .to redirect_to(:three_to_ten_k_project_accounts)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -106,7 +106,7 @@ RSpec.describe Project::CheckAnswersController do
 
       expect(response).to have_http_status(:redirect)
       expect(response)
-          .to redirect_to(:three_to_ten_k_project_accounts_get)
+          .to redirect_to(:three_to_ten_k_project_accounts)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -140,7 +140,7 @@ RSpec.describe Project::CheckAnswersController do
 
       expect(response).to have_http_status(:redirect)
       expect(response)
-          .to redirect_to(:three_to_ten_k_project_governing_docs_get)
+          .to redirect_to(:three_to_ten_k_project_governing_documents)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 

--- a/spec/controllers/project/costs_controller_spec.rb
+++ b/spec/controllers/project/costs_controller_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe Project::CostsController do
           }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_project_costs)
+      expect(response).to redirect_to(:three_to_ten_k_project_costs)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).project_costs.first.errors.empty?)
@@ -338,7 +338,7 @@ RSpec.describe Project::CostsController do
 
       expect(response).to have_http_status(:redirect)
       expect(response)
-          .to redirect_to(:three_to_ten_k_project_cash_contributions_question_get)
+          .to redirect_to(:three_to_ten_k_project_are_you_getting_cash_contributions)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -400,7 +400,7 @@ RSpec.describe Project::CostsController do
 
       expect(response).to have_http_status(:redirect)
       expect(response)
-          .to redirect_to(:three_to_ten_k_project_project_costs)
+          .to redirect_to(:three_to_ten_k_project_costs)
 
     end
 

--- a/spec/controllers/project/dates_controller_spec.rb
+++ b/spec/controllers/project/dates_controller_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Project::DatesController do
           }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_location_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_location)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 

--- a/spec/controllers/project/declaration_controller_spec.rb
+++ b/spec/controllers/project/declaration_controller_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Project::DeclarationController do
 
         expect(response).to have_http_status(:redirect)
         expect(response).to redirect_to(
-                                :three_to_ten_k_project_application_submitted_get
+                                :three_to_ten_k_project_application_submitted
                             )
 
         expect(assigns(:project).errors.empty?).to eq(true)
@@ -158,7 +158,7 @@ RSpec.describe Project::DeclarationController do
 
       expect(response).to have_http_status(:redirect)
       expect(response).to redirect_to(
-                              :three_to_ten_k_project_confirm_declaration_get
+                              :three_to_ten_k_project_confirm_declaration
                           )
 
       expect(assigns(:project).errors.empty?).to eq(true)
@@ -216,7 +216,7 @@ end
 
       expect(response).to have_http_status(:redirect)
       expect(response).to redirect_to(
-                              :three_to_ten_k_project_confirm_declaration_get
+                              :three_to_ten_k_project_confirm_declaration
                           )
 
       expect(assigns(:project).errors.empty?).to eq(true)
@@ -239,7 +239,7 @@ end
 
       expect(response).to have_http_status(:redirect)
       expect(response).to redirect_to(
-                              :three_to_ten_k_project_confirm_declaration_get
+                              :three_to_ten_k_project_confirm_declaration
                           )
 
       expect(assigns(:project).errors.empty?).to eq(true)
@@ -290,7 +290,7 @@ end
 
       expect(response).to have_http_status(:redirect)
       expect(response).to redirect_to(
-                              :three_to_ten_k_project_confirm_declaration_get
+                              :three_to_ten_k_project_confirm_declaration
                           )
 
       expect(assigns(:project).errors.empty?).to eq(true)

--- a/spec/controllers/project/description_controller_spec.rb
+++ b/spec/controllers/project/description_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Project::DescriptionController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_capital_works_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_capital_works)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).description).to eq("Test description")

--- a/spec/controllers/project/difference_controller_spec.rb
+++ b/spec/controllers/project/difference_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Project::DifferenceController do
           params: { project_id: project.id }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_matter_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_how_does_your_project_matter)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -46,7 +46,7 @@ RSpec.describe Project::DifferenceController do
           }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_matter_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_how_does_your_project_matter)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -85,7 +85,7 @@ RSpec.describe Project::DifferenceController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_matter_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_how_does_your_project_matter)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).difference).to eq("Test")

--- a/spec/controllers/project/evidence_of_support_controller_spec.rb
+++ b/spec/controllers/project/evidence_of_support_controller_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Project::EvidenceOfSupportController do
 
       expect(response).to have_http_status(:redirect)
       expect(response)
-          .to redirect_to(:three_to_ten_k_project_project_support_evidence)
+          .to redirect_to(:three_to_ten_k_project_evidence_of_support)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).evidence_of_support.first.errors.empty?)
@@ -206,7 +206,7 @@ RSpec.describe Project::EvidenceOfSupportController do
 
       expect(response).to have_http_status(:redirect)
       expect(response)
-          .to redirect_to(:three_to_ten_k_project_project_support_evidence)
+          .to redirect_to(:three_to_ten_k_project_evidence_of_support)
 
     end
 

--- a/spec/controllers/project/governing_documents_controller_spec.rb
+++ b/spec/controllers/project/governing_documents_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Project::GoverningDocumentsController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_governing_docs_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_governing_documents)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(project.governing_document_file.present?).to eq(true)

--- a/spec/controllers/project/heritage_controller_spec.rb
+++ b/spec/controllers/project/heritage_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Project::HeritageController do
           params: { project_id: project.id }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_best_placed_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_why_is_your_organisation_best_placed)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -46,7 +46,7 @@ RSpec.describe Project::HeritageController do
           }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_best_placed_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_why_is_your_organisation_best_placed)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -85,7 +85,7 @@ RSpec.describe Project::HeritageController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_best_placed_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_why_is_your_organisation_best_placed)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).heritage_description).to eq("Test")

--- a/spec/controllers/project/involvement_controller_spec.rb
+++ b/spec/controllers/project/involvement_controller_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Project::InvolvementController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_other_outcomes_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_our_other_outcomes)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).involvement_description).to eq("Test")

--- a/spec/controllers/project/location_controller_spec.rb
+++ b/spec/controllers/project/location_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Project::LocationController do
       put :update,
           params: {project_id: project.id, project: {same_location: 'yes'}}
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_description_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_description)
       Project.find(project.id) do |p|
         expect(p.line1).to eq('line1')
         expect(p.line2).to eq('line2')

--- a/spec/controllers/project/matter_controller_spec.rb
+++ b/spec/controllers/project/matter_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Project::MatterController do
           params: { project_id: project.id }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_heritage_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_your_project_heritage)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -46,7 +46,7 @@ RSpec.describe Project::MatterController do
           }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_heritage_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_your_project_heritage)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -85,7 +85,7 @@ RSpec.describe Project::MatterController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_heritage_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_your_project_heritage)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).matter).to eq("Test")

--- a/spec/controllers/project/new_project_controller_spec.rb
+++ b/spec/controllers/project/new_project_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Project::NewProjectController do
       get :create_new_project
       expect(response).to have_http_status(:redirect)
       expect(response).to redirect_to(
-                              three_to_ten_k_project_title_get_path(
+                              three_to_ten_k_project_title_path(
                                   project_id: assigns(:project).id)
                           )
       expect(assigns(:project)).to be_instance_of(Project)

--- a/spec/controllers/project/non_cash_contributions_controller_spec.rb
+++ b/spec/controllers/project/non_cash_contributions_controller_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Project::NonCashContributionsController do
 
       expect(response).to have_http_status(:redirect)
       expect(response)
-          .to redirect_to(:three_to_ten_k_project_non_cash_contributions_get)
+          .to redirect_to(:three_to_ten_k_project_non_cash_contributions)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -340,7 +340,7 @@ RSpec.describe Project::NonCashContributionsController do
 
       expect(response).to have_http_status(:redirect)
       expect(response)
-          .to redirect_to(:three_to_ten_k_project_non_cash_contributions_get)
+          .to redirect_to(:three_to_ten_k_project_non_cash_contributions)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).non_cash_contributions.first.errors.empty?)
@@ -406,7 +406,7 @@ RSpec.describe Project::NonCashContributionsController do
 
       expect(response).to have_http_status(:redirect)
       expect(response)
-          .to redirect_to(:three_to_ten_k_project_non_cash_contributions_get)
+          .to redirect_to(:three_to_ten_k_project_non_cash_contributions)
 
     end
 

--- a/spec/controllers/project/outcomes_controller_spec.rb
+++ b/spec/controllers/project/outcomes_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Project::OutcomesController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_project_costs)
+      expect(response).to redirect_to(:three_to_ten_k_project_costs)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 
@@ -145,7 +145,7 @@ RSpec.describe Project::OutcomesController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_project_costs)
+      expect(response).to redirect_to(:three_to_ten_k_project_costs)
 
       expect(assigns(:project).errors.empty?).to eq(true)
 

--- a/spec/controllers/project/permission_controller_spec.rb
+++ b/spec/controllers/project/permission_controller_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Project::PermissionController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_difference_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_difference)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).permission_type).to eq("no")
@@ -150,7 +150,7 @@ RSpec.describe Project::PermissionController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_difference_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_difference)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).permission_type).to eq("yes")
@@ -170,7 +170,7 @@ RSpec.describe Project::PermissionController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_difference_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_difference)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).permission_type).to eq("x_not_sure")

--- a/spec/controllers/project/title_controller_spec.rb
+++ b/spec/controllers/project/title_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Project::TitleController do
       }
 
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(:three_to_ten_k_project_dates_get)
+      expect(response).to redirect_to(:three_to_ten_k_project_key_dates)
 
       expect(assigns(:project).errors.empty?).to eq(true)
       expect(assigns(:project).project_title).to eq("Test project title")


### PR DESCRIPTION
We had a number of different sections in this file, some mapped to different models, such as `organisation` and `project`, and others for static pages.

We haven't been consistent with our approach in how we break out some of these routes into namespaces, which has left the file quite cluttered and created some debt.

The debt mostly exists where we haven't been consistent with our namespacing approach, which has led to us having to alias routes to then use them in controllers, tests, etc.

This pull request addresses this debt.