### PR TITLE
Added isAlsoApplicant flag to Salesforce payload

### DIFF
--- a/app/models/legal_signatory.rb
+++ b/app/models/legal_signatory.rb
@@ -1,11 +1,3 @@
-class IsNotSameAsMainContactValidator < ActiveModel::EachValidator
-  def validate_each(record, attribute, value)
-    if value == User.find_by(organisation_id: record.organisation).email
-      record.errors[attribute] << (options[:message] || "must be different to your email address")
-    end
-  end
-end
-
 class DoesNotMatchOtherSignatoryValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     if record == record.organisation.legal_signatories.second && value == record.organisation.legal_signatories.first.email_address
@@ -13,9 +5,6 @@ class DoesNotMatchOtherSignatoryValidator < ActiveModel::EachValidator
     end
   end
 end
-
-
-
 
 class LegalSignatory < ApplicationRecord
   belongs_to :organisation
@@ -38,7 +27,6 @@ class LegalSignatory < ApplicationRecord
   #       See: https://github.com/heritagefund/funding-frontend/issues/244
   validates :email_address,
             format: { with: URI::MailTo::EMAIL_REGEXP },
-            is_not_same_as_main_contact: true,
             does_not_match_other_signatory: true,
             unless: lambda {
                 |record| ignore_validation_for_empty_second_signatory?(record)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -436,6 +436,8 @@ class Project < ApplicationRecord
                     json.set!("name", ls.name)
                     json.set!("email", ls.email_address)
                     json.set!("phone", ls.phone_number)
+                    # Salesforce uses this flag to determine whether or not to create a single Contact object
+                    json.set!("isAlsoApplicant", self.user.email == ls.email_address)
                     #TODO: Remove or replace with model attribute
                     json.set!("role", "")
                 }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Project, type: :model do
       legal_signatory_one = build(
           :legal_signatory,
           name: "Joe Bloggs",
-          email_address: "joe@bloggs.com",
+          email_address: @project.user.email,
           phone_number: "07123456789"
       )
 
@@ -121,13 +121,17 @@ RSpec.describe Project, type: :model do
       expect(project_salesforce_json['application']['authorisedSignatoryOneDetails']['name'])
           .to eq("Joe Bloggs")
       expect(project_salesforce_json['application']['authorisedSignatoryOneDetails']['email'])
-          .to eq("joe@bloggs.com")
+          .to eq(@project.user.email)
+      expect(project_salesforce_json['application']['authorisedSignatoryOneDetails']['isAlsoApplicant'])
+          .to eq(true)
       expect(project_salesforce_json['application']['authorisedSignatoryOneDetails']['phone'])
           .to eq("07123456789")
       expect(project_salesforce_json['application']['authorisedSignatoryTwoDetails']['name'])
           .to eq("Jane Bloggs")
       expect(project_salesforce_json['application']['authorisedSignatoryTwoDetails']['email'])
           .to eq("jane@bloggs.com")
+      expect(project_salesforce_json['application']['authorisedSignatoryTwoDetails']['isAlsoApplicant'])
+          .to eq(false)
       expect(project_salesforce_json['application']['authorisedSignatoryTwoDetails']['phone'])
           .to eq("07987654321")
 


### PR DESCRIPTION
## Proposed changes

This commit adds the `isAlsoApplicant flag` to the Salesforce payload which is generated from the project model. This flag is used by Salesforce to determine whether or not to create only one Contact object if a user and a legal signatory have the same email address.

As a result, the temporary validation rule we had in place on the legal signatory model has been removed.

## Further comments

N/A

## Screenshot (if applicable)

## Checklist

- [x] Added tests for new functionality, or updated existing tests
- [x] Updated `README.md` if necessary