### PR TITLE
Send Devise notifications asynchronously

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,7 +50,14 @@ class User < ApplicationRecord
     end
   end
 
-    def self.current_user(user_id)
-        @user = User.find_by(uid: user_id)
-    end
+  def self.current_user(user_id)
+      @user = User.find_by(uid: user_id)
+  end
+
+  # Override the send_devise_notification method to allow for
+  # non-blocking sending using ActiveJob
+  def send_devise_notification(notification, *args)
+    devise_mailer.send(notification, self, *args).deliver_later
+  end
+
 end


### PR DESCRIPTION
## Proposed changes

This commit changes the way in which we send Devise notifications (confirm account, reset password, etc.) to send this in a non-blocking way - using ActiveJob.

This has been done as per the guidance in the Devise documentation - overriding the send_devise_notifcation method within the user model.

## Further comments

See https://github.com/heartcombo/devise#activejob-integration for more context.

We didn't have any testing for this area of the application, and it seemed like overkill to start writing new tests to assert that `deliver_later` is called rather than `deliver` - it's something we can pick up separately when we come to test this area.

## Screenshot (if applicable)

## Checklist

- [x] Added tests for new functionality, or updated existing tests
- [x] Updated `README.md` if necessary