### PR TITLE
fix direct upload error message

### DIFF
--- a/app/views/partials/_file_upload_error.html.erb
+++ b/app/views/partials/_file_upload_error.html.erb
@@ -1,4 +1,4 @@
 <span id="file-upload-error" class="govuk-error-message">
   <span class="govuk-visually-hidden">Error:</span>
-  <%= t('errors.views.file_upload_error_message') %>
+  <%= I18n.t('activestorage.errors.file_upload_error_message') %>
 </span>

--- a/app/views/partials/_file_upload_error_summary.html.erb
+++ b/app/views/partials/_file_upload_error_summary.html.erb
@@ -9,7 +9,7 @@
     <ul class="govuk-list govuk-error-summary__list">
       <li>
         <a href='#file-upload-form-group'>
-          <%= t('errors.views.file_upload_error_message') %>
+          <%= I18n.t('activestorage.errors.file_upload_error_message') %>
         </a>
       </li>
     </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,9 @@ en-GB:
           outcome_8: "The local area will be a better place to live, work or visit"
           outcome_9: "The local economy will be boosted"
         evidence_of_support: "Evidence of support"
+  activestorage:
+    errors:
+      file_upload_error_message: "The upload of this file has failed"
   activerecord:
     attributes:
       legal_signatory:
@@ -53,8 +56,6 @@ en-GB:
         company_number: "Company number"
         charity_number: "Charity number"
     errors:
-      views:
-        file_upload_error_message: "The upload of this file has failed"
       models:
         user:
           attributes:


### PR DESCRIPTION
## Proposed changes

Bug fix. Previously this message was not displaying correctly because of incorrect indentation in the locales file it was nested under `activerecord`. I have moved it and created a more descriptive namespace.

## Before
![Screenshot 2020-04-15 at 15 10 00](https://user-images.githubusercontent.com/1764158/79352507-dca2c000-7f31-11ea-8190-706908d1178c.png)

## After
![Screenshot 2020-04-15 at 15 02 41](https://user-images.githubusercontent.com/1764158/79352534-e4626480-7f31-11ea-8468-06703f511f7a.png)
