### PR TITLE
fix heading on cookie details page

### DIFF
--- a/app/views/help/cookie_details.html.erb
+++ b/app/views/help/cookie_details.html.erb
@@ -39,7 +39,7 @@
 </table>
 
 <h2 class="govuk-heading-m">
-  Cookie policy settings
+  Session cookies
 </h2>
 <p class="govuk-body">
   We store session cookies on your computer to help keep your information secure while you use the service.


### PR DESCRIPTION
Heading was erroneously duplicated.