### PR TITLE
add missing legend for legal signatories

### DIFF
--- a/app/views/organisation/signatories/show.html.erb
+++ b/app/views/organisation/signatories/show.html.erb
@@ -62,15 +62,15 @@
   <%= f.fields_for :legal_signatories do |ls| %>
 
     <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
-
-      <h2 class="govuk-heading-m" aria-label="Heading">
-        <%#
+      <legend>
+        <h2 class="govuk-heading-m" aria-label="Heading">
+          <%#
             We are using ls.index + 1 here to display '1' and '2'
             as :legal_signatories is zero-indexed
-        %>
-        Legal signatory <%= ls.index + 1 %>
-      </h2>
-
+          %>
+          Legal signatory <%= ls.index + 1 %>
+        </h2>
+      </legend>
       <div class="govuk-form-group <%= "#{'govuk-form-group--error' if
           @organisation.legal_signatories[ls.index].errors[:name].any?}" %>">
 


### PR DESCRIPTION
## Proposed changes

Fixes issue found in accessibility review: https://trello.com/c/mXNP8Uh5/1445-alert-fieldset-missing-legend-on-signatories-page-organisation-id-signatories