### PR TITLE
Better handling of date of birth fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+git_source(:github) do |repo| "https://github.com/#{repo}.git" end
 
 ruby '~> 2.6.0'
 
@@ -25,6 +25,7 @@ gem 'silencer', '~> 1.0'
 gem 'turbolinks', '~> 5'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'uk_postcode', '~> 2.1.5'
+gem 'validates_timeliness', '~> 5.0.0.beta1'
 gem 'view_component', '~> 2.18.1'
 gem 'webpacker', '~> 4.0'
 
@@ -37,8 +38,8 @@ group :development, :test do
   gem 'rails-controller-testing', '~> 1.0.4'
   gem 'rspec-rails', '~> 4.0.0.beta3' # Pinned to beta version due to https://github.com/rspec/rspec-rails/issues/2086
   gem 'rubocop', '~> 0.88.0'
-  gem 'rubocop-rspec', '~> 1.42.0'
   gem 'rubocop-rails', '~> 2.7.1'
+  gem 'rubocop-rspec', '~> 1.42.0'
   gem 'ruby-debug-ide', '~> 0.7.2' # Allows for debugging in Visual Studio Code
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,6 +373,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    timeliness (0.4.4)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -383,6 +384,8 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
+    validates_timeliness (5.0.0.beta2)
+      timeliness (>= 0.3.10, < 1)
     view_component (2.18.1)
       activesupport (>= 5.0.0, < 7.0)
     virtus (1.0.5)
@@ -465,6 +468,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uk_postcode (~> 2.1.5)
+  validates_timeliness (~> 5.0.0.beta1)
   view_component (~> 2.18.1)
   web-console (>= 3.3.0)
   webdrivers
@@ -475,4 +479,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.4
+   2.2.4

--- a/app/controllers/user/details_controller.rb
+++ b/app/controllers/user/details_controller.rb
@@ -3,26 +3,15 @@ class User::DetailsController < ApplicationController
   before_action :authenticate_user!
 
   def update
-
     logger.debug "Updating user details for user ID: #{current_user.id}"
 
     current_user.validate_details = true
 
-    current_user.update(user_params)
-
-    if current_user.valid?
+    if current_user.update(user_params)
 
       # As current_user is valid, we can now merge the individual date of
       # birth fields into an individual Date object and store this in the
       # current_user's date_of_birth attribute
-
-      current_user.date_of_birth = Date.new(
-        params[:user][:dob_year].to_i,
-        params[:user][:dob_month].to_i,
-        params[:user][:dob_day].to_i
-      )
-
-      current_user.save
 
       logger.debug "Finished updating user details for user ID: #{current_user.id}"
 
@@ -45,7 +34,6 @@ class User::DetailsController < ApplicationController
       flash.discard
 
     end
-
   end
 
   private
@@ -67,11 +55,9 @@ class User::DetailsController < ApplicationController
   #
   # @param [User] user An instance of User
   def check_and_set_organisation(user)
-
     return if user.organisations.any?
 
     user.organisations.create
-
   end
 
   # Replicates a subset of attributes from the passed in User object
@@ -79,7 +65,6 @@ class User::DetailsController < ApplicationController
   #
   # @param [User] user An instance of User
   def replicate_user_attributes_to_associated_person(user)
-
     person = Person.find(user.person_id)
 
     person.update(
@@ -87,17 +72,13 @@ class User::DetailsController < ApplicationController
       date_of_birth: user.date_of_birth,
       phone_number: user.phone_number
     )
-
   end
 
   def user_params
     params.require(:user).permit(
       :name,
-      :dob_day,
-      :dob_month,
-      :dob_year,
+      :date_of_birth,
       :phone_number
     )
   end
-
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,4 +1,16 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
   nilify_blanks
+
+  def update(params)
+    super params
+  rescue ActiveRecord::MultiparameterAssignmentErrors => e
+    e.errors.each do |error|
+      errors.add(
+        error.attribute,
+        I18n.t("activerecord.errors.models.#{self.class.name.underscore}.attributes.#{error.attribute}.invalid")
+      )
+    end
+    false
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,16 +1,4 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
   nilify_blanks
-
-  def update(params)
-    super params
-  rescue ActiveRecord::MultiparameterAssignmentErrors => e
-    e.errors.each do |error|
-      errors.add(
-        error.attribute,
-        I18n.t("activerecord.errors.models.#{self.class.name.underscore}.attributes.#{error.attribute}.invalid")
-      )
-    end
-    false
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@ class User < ApplicationRecord
   validates :townCity, presence: true, if: :validate_address?
   validates :county, presence: true, if: :validate_address?
   validates :postcode, presence: true, if: :validate_address?
+  validates_date :date_of_birth, before: :today, if: :validate_details?
 
   validate :date_of_birth_is_in_past, if: :validate_details?
 
@@ -34,7 +35,7 @@ class User < ApplicationRecord
   end
 
   def date_of_birth_is_in_past
-    return if date_of_birth.past?
+    return if date_of_birth&.past?
 
     errors.add(:date_of_birth, 'Date of birth must be in the past')
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,25 +15,15 @@ class User < ApplicationRecord
 
   belongs_to :person, optional: true
 
-  attr_accessor :validate_details
-  attr_accessor :validate_address
-
-  # These attributes are used to set individual error messages
-  # for each of the project date input fields
-  attr_accessor :dob_day
-  attr_accessor :dob_month
-  attr_accessor :dob_year
+  attr_accessor :validate_details, :validate_address
 
   validates :name, presence: true, if: :validate_details?
-  validates :dob_day, presence: true, if: :validate_details?
-  validates :dob_month, presence: true, if: :validate_details?
-  validates :dob_year, presence: true, if: :validate_details?
   validates :line1, presence: true, if: :validate_address?
   validates :townCity, presence: true, if: :validate_address?
   validates :county, presence: true, if: :validate_address?
   validates :postcode, presence: true, if: :validate_address?
 
-  validate :date_of_birth_is_date_and_in_past?, if: :validate_details?
+  validate :date_of_birth_is_in_past, if: :validate_details?
 
   def validate_details?
     validate_details == true
@@ -43,17 +33,13 @@ class User < ApplicationRecord
     validate_address == true
   end
 
-  def date_of_birth_is_date_and_in_past?
-    unless Date.valid_date?(self.dob_year.to_i, self.dob_month.to_i, self.dob_day.to_i)
-      errors.add(:date_of_birth, 'Date of birth must be a valid date')
-    else
-      unless Date.new(self.dob_year.to_i, self.dob_month.to_i, self.dob_day.to_i).past?
-        errors.add(:date_of_birth, 'Date of birth must be in the past')
-      end
-    end
+  def date_of_birth_is_in_past
+    return if date_of_birth.past?
+
+    errors.add(:date_of_birth, 'Date of birth must be in the past')
   end
 
-    def self.current_user(user_id)
-        @user = User.find_by(uid: user_id)
-    end
+  def self.current_user(user_id)
+    @user = User.find_by(uid: user_id)
+  end
 end

--- a/app/views/user/details/show.html.erb
+++ b/app/views/user/details/show.html.erb
@@ -126,7 +126,7 @@
             <div class="govuk-form-group">
 
               <%= 
-                f.label :dob_day,
+                f.label 'date_of_birth(3i)',
                 t('details.label_day'),
                 class: "govuk-label govuk-date-input__label" 
               %>
@@ -135,7 +135,7 @@
                   form_object: current_user,
                   form_for_object: f,
                   model_attribute: :date_of_birth,
-                  input_name: :dob_day,
+                  input_name: 'date_of_birth(3i)',
                   input_width: 2,
                   date_type: "day"
               } %>
@@ -149,7 +149,7 @@
             <div class="govuk-form-group">
 
               <%= 
-                f.label :dob_month,
+                f.label 'date_of_birth(2i)',
                 t('details.label_month'),
                 class: "govuk-label govuk-date-input__label" 
               %>
@@ -158,7 +158,7 @@
                   form_object: current_user,
                   form_for_object: f,
                   model_attribute: :date_of_birth,
-                  input_name: :dob_month,
+                  input_name: 'date_of_birth(2i)',
                   input_width: 2,
                   date_type: "month"
               } %>
@@ -172,7 +172,7 @@
             <div class="govuk-form-group">
 
               <%= 
-                f.label :dob_year,
+                f.label 'date_of_birth(1i)',
                 t('details.label_year'),
                 class: "govuk-label govuk-date-input__label" 
               %>
@@ -181,7 +181,7 @@
                   form_object: current_user,
                   form_for_object: f,
                   model_attribute: :date_of_birth,
-                  input_name: :dob_year,
+                  input_name: 'date_of_birth(1i)',
                   input_width: 4,
                   date_type: "year"
               } %>

--- a/config/initializers/validates_timeliness.rb
+++ b/config/initializers/validates_timeliness.rb
@@ -1,0 +1,41 @@
+ValidatesTimeliness.setup do |config|
+  # Extend ORM/ODMs for full support (:active_record included).
+  config.extend_orms = [:active_record]
+  #
+  # Default timezone
+  # config.default_timezone = :utc
+  #
+  # Set the dummy date part for a time type values.
+  # config.dummy_date_for_time_type = [ 2000, 1, 1 ]
+  #
+  # Ignore errors when restriction options are evaluated
+  # config.ignore_restriction_errors = false
+  #
+  # Re-display invalid values in date/time selects
+  # config.enable_date_time_select_extension!
+  #
+  # Handle multiparameter date/time values strictly
+  config.enable_multiparameter_extension!
+
+  #
+  # Shorthand date and time symbols for restrictions
+  # config.restriction_shorthand_symbols.update(
+  #   :now   => lambda { Time.current },
+  #   :today => lambda { Date.current }
+  # )
+  #
+  # Use the plugin date/time parser which is stricter and extendable
+  # config.use_plugin_parser = false
+  #
+  # Add one or more formats making them valid. e.g. add_formats(:date, 'd(st|rd|th) of mmm, yyyy')
+  # config.parser.add_formats()
+  #
+  # Remove one or more formats making them invalid. e.g. remove_formats(:date, 'dd/mm/yyy')
+  # config.parser.remove_formats()
+  #
+  # Change the ambiguous year threshold when parsing a 2 digit year
+  # config.parser.ambiguous_year_threshold =  30
+  #
+  # Treat ambiguous dates, such as 01/02/1950, as a Non-US date.
+  # config.parser.remove_us_formats
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,6 +101,8 @@ en-GB:
               blank: "Enter the month in which you were born"
             dob_year:
               blank: "Enter the year in which you were born"
+            date_of_birth:
+              invalid: "Enter a valid date of birth"
             line1:
               blank: "Enter the first line of your address"
             townCity:

--- a/config/locales/validates_timeliness.en.yml
+++ b/config/locales/validates_timeliness.en.yml
@@ -1,0 +1,16 @@
+en:
+  errors:
+    messages:
+      invalid_date: "is not a valid date"
+      invalid_time: "is not a valid time"
+      invalid_datetime: "is not a valid datetime"
+      is_at: "must be at %{restriction}"
+      before: "must be before %{restriction}"
+      on_or_before: "must be on or before %{restriction}"
+      after: "must be after %{restriction}"
+      on_or_after: "must be on or after %{restriction}"
+  validates_timeliness:
+    error_value_formats:
+      date: '%Y-%m-%d'
+      time: '%H:%M:%S'
+      datetime: '%Y-%m-%d %H:%M:%S'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -325,9 +325,6 @@ ActiveRecord::Schema.define(version: 2021_01_06_084939) do
     t.integer "permission_type"
     t.text "permission_description"
     t.boolean "capital_work"
-    t.text "declaration_reasons_description"
-    t.boolean "user_research_declaration", default: false
-    t.boolean "keep_informed_declaration", default: false
     t.boolean "outcome_2"
     t.boolean "outcome_3"
     t.boolean "outcome_4"
@@ -346,6 +343,9 @@ ActiveRecord::Schema.define(version: 2021_01_06_084939) do
     t.text "outcome_9_description"
     t.boolean "is_partnership", default: false
     t.text "partnership_details"
+    t.boolean "keep_informed_declaration"
+    t.boolean "user_research_declaration"
+    t.text "declaration_reasons_description"
     t.uuid "funding_application_id"
     t.index ["funding_application_id"], name: "index_projects_on_funding_application_id"
     t.index ["user_id"], name: "index_projects_on_user_id"

--- a/spec/controllers/user/details_controller_spec.rb
+++ b/spec/controllers/user/details_controller_spec.rb
@@ -26,7 +26,21 @@ RSpec.describe User::DetailsController do
   it 'displays an error when given an invalid date' do
     user_params = {
       :name => 'Name',
-      'date_of_birth(3i)' => '32',
+      'date_of_birth(3i)' => '31',
+      'date_of_birth(2i)' => '2',
+      'date_of_birth(1i)' => '1990',
+      :phone_number => '123123123'
+    }
+
+    put :update, params: { user: user_params }
+
+    expect(response.body).to include 'is not a valid date'
+  end
+
+  it 'displays an error when given an empty date' do
+    user_params = {
+      :name => 'Name',
+      'date_of_birth(3i)' => '',
       'date_of_birth(2i)' => '14',
       'date_of_birth(1i)' => '1990',
       :phone_number => '123123123'
@@ -34,6 +48,6 @@ RSpec.describe User::DetailsController do
 
     put :update, params: { user: user_params }
 
-    expect(response.body).to include 'Enter a valid date of birth'
+    expect(response.body).to include 'is not a valid date'
   end
 end

--- a/spec/controllers/user/details_controller_spec.rb
+++ b/spec/controllers/user/details_controller_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe User::DetailsController do
+  login_user
+  render_views
+
+  describe 'PUT /user/details' do
+    it 'should update the user with valid details' do
+      user_params = {
+        :name => 'Name',
+        'date_of_birth(3i)' => '1',
+        'date_of_birth(2i)' => '1',
+        'date_of_birth(1i)' => '1990',
+        :phone_number => '123123123'
+      }
+
+      put :update, params: { user: user_params }
+
+      expect(response).to be_redirect
+
+      expect(subject.current_user.name).to eq 'Name'
+      expect(subject.current_user.date_of_birth).to eq Date.new(1990, 1, 1)
+    end
+  end
+
+  it 'displays an error when given an invalid date' do
+    user_params = {
+      :name => 'Name',
+      'date_of_birth(3i)' => '32',
+      'date_of_birth(2i)' => '14',
+      'date_of_birth(1i)' => '1990',
+      :phone_number => '123123123'
+    }
+
+    put :update, params: { user: user_params }
+
+    expect(response.body).to include 'Enter a valid date of birth'
+  end
+end

--- a/spec/features/about_you_spec.rb
+++ b/spec/features/about_you_spec.rb
@@ -10,10 +10,10 @@ RSpec.feature 'Application', type: :feature do
 
   scenario 'About you page' do
     user = FactoryBot.create(
-        :user,
-        name: nil,
-        date_of_birth: nil,
-        phone_number: nil
+      :user,
+      name: nil,
+      date_of_birth: nil,
+      phone_number: nil
     )
     login_as(user, scope: :user)
     visit('/')
@@ -25,7 +25,6 @@ RSpec.feature 'Application', type: :feature do
     fill_in 'Year', with: '1970'
     click_button 'Save and continue'
     expect(page)
-        .to have_current_path("/user/#{user.organisations.first.id}/address/postcode?locale=en-GB")
+      .to have_current_path("/user/#{user.organisations.first.id}/address/postcode?locale=en-GB")
   end
-
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Project, type: :model do
+  describe 'date_of_birth' do
+    it 'can be set from form params' do
+      user = User.new
+
+      user.assign_attributes({
+                               'date_of_birth(3i)' => '1',
+                               'date_of_birth(2i)' => '1',
+                               'date_of_birth(1i)' => '1990'
+                             })
+
+      expect(user.date_of_birth).to eq Date.new(1990, 1, 1)
+    end
+
+    it 'fails to assign an invalid date' do
+      user = User.new
+      expect {
+        user.assign_attributes({
+                                 'date_of_birth(3i)' => '32',
+                                 'date_of_birth(2i)' => '14',
+                                 'date_of_birth(1i)' => '1990'
+                               })
+      }.to raise_error ActiveRecord::MultiparameterAssignmentErrors
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,13 +16,16 @@ RSpec.describe Project, type: :model do
 
     it 'fails to assign an invalid date' do
       user = User.new
-      expect {
-        user.assign_attributes({
-                                 'date_of_birth(3i)' => '32',
-                                 'date_of_birth(2i)' => '14',
-                                 'date_of_birth(1i)' => '1990'
-                               })
-      }.to raise_error ActiveRecord::MultiparameterAssignmentErrors
+
+      user.assign_attributes({
+                               'date_of_birth(3i)' => '32',
+                               'date_of_birth(2i)' => '14',
+                               'date_of_birth(1i)' => '1990'
+                             })
+
+      user.validate_details = true
+
+      expect(user).not_to be_valid
     end
   end
 end


### PR DESCRIPTION
Instead of manually handling parsing and error checks for day/month/year fields, we can treat the full date as a single entity.

Both rails params and activemodel callbacks automatically handle multipart fields such as dates and times
Only a small quirk was needed, because in the event of an invalid date (e.g.: 32nd of January), instead of a model error, an exception is raised.

The solution is to patch `ActiveRecord::Base.update` to handle that exception, by adding the corresponding errors to the model and return gracefully