### PR TITLE
validating Person#email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+git_source(:github) do |repo| "https://github.com/#{repo}.git" end
 
 ruby '~> 2.6.0'
 
@@ -25,6 +25,7 @@ gem 'silencer', '~> 1.0'
 gem 'turbolinks', '~> 5'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'uk_postcode', '~> 2.1.5'
+gem 'valid_email2'
 gem 'view_component', '~> 2.18.1'
 gem 'webpacker', '~> 4.0'
 
@@ -37,8 +38,8 @@ group :development, :test do
   gem 'rails-controller-testing', '~> 1.0.4'
   gem 'rspec-rails', '~> 4.0.0.beta3' # Pinned to beta version due to https://github.com/rspec/rspec-rails/issues/2086
   gem 'rubocop', '~> 0.88.0'
-  gem 'rubocop-rspec', '~> 1.42.0'
   gem 'rubocop-rails', '~> 2.7.1'
+  gem 'rubocop-rspec', '~> 1.42.0'
   gem 'ruby-debug-ide', '~> 0.7.2' # Allows for debugging in Visual Studio Code
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,6 +383,9 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
+    valid_email2 (3.5.0)
+      activemodel (>= 3.2)
+      mail (~> 2.5)
     view_component (2.18.1)
       activesupport (>= 5.0.0, < 7.0)
     virtus (1.0.5)
@@ -465,6 +468,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uk_postcode (~> 2.1.5)
+  valid_email2
   view_component (~> 2.18.1)
   web-console (>= 3.3.0)
   webdrivers
@@ -475,4 +479,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.4
+   2.2.4

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,18 +1,14 @@
 class Person < ApplicationRecord
-
-  self.implicit_order_column = "created_at"
+  self.implicit_order_column = 'created_at'
 
   has_many :funding_applications_people, inverse_of: :person
   has_many :funding_applications, through: :funding_applications_people
 
-  attr_accessor :validate_name
-  attr_accessor :validate_position
-  attr_accessor :validate_email
-  attr_accessor :validate_phone_number
+  attr_accessor :validate_name, :validate_position, :validate_email, :validate_phone_number
 
   validates :name, presence: true, if: :validate_name?
   validates :position, presence: true, if: :validate_position?
-  validates :email, presence: true, if: :validate_email? 
+  validates :email, presence: true, 'valid_email2/email': true, if: :validate_email?
   validates :phone_number, presence: true, if: :validate_phone_number?
 
   def validate_name?
@@ -30,5 +26,4 @@ class Person < ApplicationRecord
   def validate_phone_number?
     validate_phone_number == true
   end
-
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Person, type: :model do
+  context '#valid?' do
+    it 'accepts valid email addresses' do
+      user = build(:person, email: 'test@gmail.com')
+      user.validate_email = true
+
+      expect(user).to be_valid
+    end
+
+    it 'does not accept invalid emails' do
+      user = build(:person, email: 'test')
+      user.validate_email = true
+
+      expect(user).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
Email fields can be validated using the https://github.com/micke/valid_email2 gem, which does not use a regex (which is sometimes a dangerous approach), and allows for extra options, should you need them, such as doing MX record checks to get extra guarantees that the domain name actually has an email server (e.g.: "test@invalid-gmail.com" would fail")

Those optional checks are not enabled here, but can be easily added (check documentation on the gem's Readme)