### PR TITLE
Abstracted organisation numbers markup into partial

### DIFF
--- a/app/views/organisation/numbers/show.html.erb
+++ b/app/views/organisation/numbers/show.html.erb
@@ -19,53 +19,15 @@
 
 <%= form_with model: @organisation, url: :organisation_numbers, method: :put, local: true do |f|  %>
 
-  <div class="govuk-form-group">
-
-    <%= f.label :company_number, t('organisation.numbers.labels.company_number'), class: "govuk-heading-m" %>
-
-    <span class="govuk-hint">
-      <%= t('organisation.numbers.hints.company_number') %>
-    </span>
-
-    <%=
-      render partial: "partials/form_input_errors",
-             locals: {
-                 form_object: @organisation,
-                 input_field_id: :company_number
-             } if @organisation.errors[:company_number].any?
-    %>
-
-    <%=
-      f.text_field :company_number,
-                     class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if
-                         @organisation.errors[:company_number].any?}"
-    %>
-
-  </div>
-
-  <div class="govuk-form-group">
-
-    <%= f.label :charity_number, t('organisation.numbers.labels.charity_number'), class: "govuk-heading-m" %>
-
-    <span class="govuk-hint">
-      <%= t('organisation.numbers.hints.charity_number') %>
-    </span>
-
-    <%=
-      render partial: "partials/form_input_errors",
-             locals: {
-                 form_object: @organisation,
-                 input_field_id: :charity_number
-             } if @organisation.errors[:charity_number].any?
-    %>
-
-    <%=
-      f.text_field :charity_number,
-                   class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if
-                       @organisation.errors[:charity_number].any?}"
-    %>
-
-  </div>
+  <%=
+    render(
+      partial: 'partials/organisation/numbers_question',
+      locals: {
+        model_object: @organisation,
+        form_object: f
+      }
+    )
+  %>
 
   <%= render(ButtonComponent.new(element: 'input')) %>
 

--- a/app/views/partials/organisation/_numbers_question.html.erb
+++ b/app/views/partials/organisation/_numbers_question.html.erb
@@ -1,0 +1,59 @@
+<div class="govuk-form-group">
+
+  <%=
+    form_object.label :company_number,
+    t('organisation.numbers.labels.company_number'),
+    class: "govuk-heading-m"
+  %>
+
+  <span class="govuk-hint">
+    <%= t('organisation.numbers.hints.company_number') %>
+  </span>
+
+  <%=
+    render(
+      partial: "partials/form_input_errors",
+      locals: {
+        form_object: model_object,
+        input_field_id: :company_number
+      } 
+    ) if model_object.errors[:company_number].any?
+  %>
+
+  <%=
+    form_object.text_field :company_number,
+    class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if 
+      model_object.errors[:company_number].any?}"
+  %>
+
+</div>
+
+<div class="govuk-form-group">
+
+  <%=
+    form_object.label :charity_number,
+    t('organisation.numbers.labels.charity_number'),
+    class: "govuk-heading-m"
+  %>
+
+  <span class="govuk-hint">
+    <%= t('organisation.numbers.hints.charity_number') %>
+  </span>
+
+  <%=
+    render(
+      partial: "partials/form_input_errors",
+      locals: {
+        form_object: model_object,
+        input_field_id: :charity_number
+      }
+    ) if model_object.errors[:charity_number].any?
+  %>
+
+  <%=
+    form_object.text_field :charity_number,
+    class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if
+      model_object.errors[:charity_number].any?}"
+  %>
+
+</div>


### PR DESCRIPTION
## Proposed changes

This commit abstracts the organisation numbers markup into a partial so that it can be referenced by multiple application journeys.

## Further comments

N/A.

## Screenshot (if applicable)

N/A.

## Checklist

- [ ] Added tests for new functionality, or updated existing tests
- [ ] Updated `README.md` if necessary