### PR TITLE
Abstracted organisation signatories markup into partial

### DIFF
--- a/app/views/organisation/signatories/show.html.erb
+++ b/app/views/organisation/signatories/show.html.erb
@@ -21,10 +21,10 @@
       <ul class="govuk-list govuk-error-summary__list">
 
         <% @organisation.legal_signatories.each_with_index do |ls, index| %>
-          <% ls.errors.each do |attr, msg| %>
+          <% ls.errors.each do |error| %>
             <li>
-              <a href='#organisation_legal_signatories_attributes_<%= index %>_<%= attr %>'>
-                <%= msg %>
+              <a href='#organisation_legal_signatories_attributes_<%= index %>_<%= error.attribute %>'>
+                <%= error.message %>
               </a>
             </li>
           <% end %>
@@ -59,105 +59,20 @@
 
 <%=
   form_with model: @organisation,
-            url: :organisation_signatories,
-            method: :put,
-            local: true do |f|
+  url: :organisation_signatories,
+  method: :put,
+  local: true do |f|
 %>
 
-  <%= f.fields_for :legal_signatories do |ls| %>
-
-    <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-        <h2 class="govuk-fieldset__heading">
-          <%#
-            We are using ls.index + 1 here to display '1' and '2'
-            as :legal_signatories is zero-indexed
-          %>
-          <%= "#{t('organisation.signatories.legal_signatory')} #{ls.index + 1}" %>
-        </h2>
-      </legend>
-      <div class="govuk-form-group <%= "#{'govuk-form-group--error' if
-          @organisation.legal_signatories[ls.index].errors[:name].any?}" %>">
-
-        <%=
-          render(
-            partial: "partials/form_input_errors",
-            locals: {
-              form_object: @organisation.legal_signatories[ls.index],
-              input_field_id: :name
-            }
-          ) if @organisation.legal_signatories[ls.index].errors[:name].any?
-        %>
-
-        <%=
-          ls.label :name,
-          t('organisation.signatories.labels.full_name'),
-          class: "govuk-label"
-        %>
-
-        <%=
-          ls.text_field :name,
-          class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if
-            @organisation.legal_signatories[ls.index].errors[:name].any?}"
-        %>
-      </div>
-
-      <div class="govuk-form-group <%= "#{'govuk-form-group--error' if
-          @organisation.legal_signatories[ls.index].errors[:email_address].any?}" %>">
-
-        <%=
-          render(
-            partial: "partials/form_input_errors",
-            locals: {
-              form_object: @organisation.legal_signatories[ls.index],
-              input_field_id: :email_address
-            }
-          ) if @organisation.legal_signatories[ls.index].errors[:email_address].any?
-        %>
-
-        <%=
-          ls.label :email_address,
-          t('organisation.signatories.labels.email_address'),
-          class: "govuk-label"
-        %>
-
-        <%=
-          ls.text_field :email_address,
-          class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if
-            @organisation.legal_signatories[ls.index].errors[:email_address].any?}"
-        %>
-      </div>
-
-      <div class="govuk-form-group <%= "#{'govuk-form-group--error' if
-          @organisation.legal_signatories[ls.index].errors[:phone_number].any?}" %>">
-
-        <%=
-          render(
-            partial: "partials/form_input_errors",
-            locals: {
-              form_object: @organisation.legal_signatories[ls.index],
-              input_field_id: :phone_number
-            }
-          ) if @organisation.legal_signatories[ls.index].errors[:phone_number].any?
-        %>
-
-        <%=
-          ls.label :phone_number,
-          t('organisation.signatories.labels.phone_number'),
-          class: "govuk-label"
-        %>
-
-        <%=
-          ls.text_field :phone_number,
-          class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if
-            @organisation.legal_signatories[ls.index].errors[:phone_number].any?}"
-        %>
-
-      </div>
-
-    </fieldset>
-
-  <% end %>
+  <%=
+    render(
+      partial: 'partials/organisation/signatories_question',
+      locals: {
+        model_object: @organisation,
+        form_object: f
+      }
+    )
+  %>
 
   <%= render(ButtonComponent.new(element: 'input')) %>
 

--- a/app/views/partials/organisation/_signatories_question.html.erb
+++ b/app/views/partials/organisation/_signatories_question.html.erb
@@ -1,0 +1,96 @@
+<%= form_object.fields_for :legal_signatories do |ls| %>
+
+  <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
+
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+      <h2 class="govuk-fieldset__heading">
+        <%#
+          We are using ls.index + 1 here to display '1' and '2'
+          as :legal_signatories is zero-indexed
+        %>
+        <%= "#{t('organisation.signatories.legal_signatory')} #{ls.index + 1}" %>
+      </h2>
+    </legend>
+
+    <div class="govuk-form-group <%= "#{'govuk-form-group--error' if
+        model_object.legal_signatories[ls.index].errors[:name].any?}" %>">
+
+      <%=
+        render(
+          partial: "partials/form_input_errors",
+          locals: {
+            form_object: model_object.legal_signatories[ls.index],
+            input_field_id: :name
+          }
+        ) if model_object.legal_signatories[ls.index].errors[:name].any?
+      %>
+
+      <%=
+        ls.label :name,
+        t('organisation.signatories.labels.full_name'),
+        class: "govuk-label"
+      %>
+
+      <%=
+        ls.text_field :name,
+        class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if
+          model_object.legal_signatories[ls.index].errors[:name].any?}"
+      %>
+    </div>
+
+    <div class="govuk-form-group <%= "#{'govuk-form-group--error' if
+        model_object.legal_signatories[ls.index].errors[:email_address].any?}" %>">
+
+      <%=
+        render(
+          partial: "partials/form_input_errors",
+          locals: {
+            form_object: model_object.legal_signatories[ls.index],
+            input_field_id: :email_address
+          }
+        ) if model_object.legal_signatories[ls.index].errors[:email_address].any?
+      %>
+
+      <%=
+        ls.label :email_address,
+        t('organisation.signatories.labels.email_address'),
+        class: "govuk-label"
+      %>
+
+      <%=
+        ls.text_field :email_address,
+        class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if
+          model_object.legal_signatories[ls.index].errors[:email_address].any?}"
+      %>
+    </div>
+
+    <div class="govuk-form-group <%= "#{'govuk-form-group--error' if
+        model_object.legal_signatories[ls.index].errors[:phone_number].any?}" %>">
+
+      <%=
+        render(
+          partial: "partials/form_input_errors",
+          locals: {
+            form_object: model_object.legal_signatories[ls.index],
+            input_field_id: :phone_number
+          }
+        ) if model_object.legal_signatories[ls.index].errors[:phone_number].any?
+      %>
+
+      <%=
+        ls.label :phone_number,
+        t('organisation.signatories.labels.phone_number'),
+        class: "govuk-label"
+      %>
+
+      <%=
+        ls.text_field :phone_number,
+        class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if
+          model_object.legal_signatories[ls.index].errors[:phone_number].any?}"
+      %>
+
+    </div>
+
+  </fieldset>
+
+<% end %>


### PR DESCRIPTION
## Proposed changes

This commit abstracts the organisation signatories markup into a partial so that it can be referenced by multiple application journeys.

## Further comments

N/A.

## Screenshot (if applicable)

N/A.

## Checklist

- [ ] Added tests for new functionality, or updated existing tests
- [ ] Updated `README.md` if necessary