### PR TITLE
Check if `HOST_URI` is set to prevent fail during assets compilation

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   # Code is not reloaded between requests.
   config.cache_classes = true
 
-  # config.hosts << ENV.fetch("HOST_URI")
+  config.hosts << ENV.fetch("HOST_URI") if ENV.has_key?("HOST_URI")
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.

--- a/config/environments/research.rb
+++ b/config/environments/research.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
   config.cache_classes = true
 
   # Set azure as hosts
-  config.hosts << ENV.fetch("HOST_URI")
+  config.hosts << ENV.fetch("HOST_URI") if ENV.has_key?("HOST_URI")
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers

--- a/config/environments/training.rb
+++ b/config/environments/training.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
   config.cache_classes = true
 
   # Set azure as hosts
-  config.hosts << ENV.fetch("HOST_URI")
+  config.hosts << ENV.fetch("HOST_URI") if ENV.has_key?("HOST_URI")
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
   config.cache_classes = true
 
     # Set azure as hosts
-    config.hosts << ENV.fetch("HOST_URI")
+    config.hosts << ENV.fetch("HOST_URI") if ENV.has_key?("HOST_URI")
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers


### PR DESCRIPTION
## Proposed changes

Added check to verify if `HOST_URI` ENV variable is present as if not present, by using `fetch` and not providing fallback it will raise an error.

Other possible solutions:
 - just use `ENV["HOST_URI"]
 - set `HOST_URI` in Dockerfile 
```
RUN HOST_URI="localhost" SKIP_SALESFORCE_INIT=true SKIP_FLIPPER_INIT=true SECRET_KEY_BASE=DUMMY ./bin/rails assets:precompile
```

## Further comments

None

## Screenshot (if applicable)

## Checklist
