### PR TITLE
fix: Fix related links section alignment to match other pages

### DIFF
--- a/app/views/partials/summary/_summary_link.html.erb
+++ b/app/views/partials/summary/_summary_link.html.erb
@@ -5,11 +5,8 @@
   </h2>
 
   <p class="govuk-body govuk-!-margin-bottom-0">
-    <%= 
-      link_to t('views.summary.related_link_text'),
-        summary_link,
-      class: 'govuk-link govuk-link--no-visited-state' 
-    %>
+    <%= link_to t('views.summary.related_link_text'), summary_link,
+      class: 'govuk-link govuk-link--no-visited-state' %>
   </p>
 
 </div>

--- a/app/views/pre_application/project_enquiry/programme_outcomes/show.html.erb
+++ b/app/views/pre_application/project_enquiry/programme_outcomes/show.html.erb
@@ -7,10 +7,10 @@
 %>
 
 <%= content_for :secondarycontent do %>
-  <%= 
+  <%=
     render partial: "partials/summary/summary_link", locals: {
       summary_link: pre_application_project_enquiry_summary_path
-    } 
+    }
   %>
 <% end %>
 
@@ -25,66 +25,58 @@
   method: :put do |f| 
 %>
 
-<div class="govuk-character-count" data-module="govuk-character-count"
-      data-maxwords="200">
-  <div class="govuk-form-group <%= "govuk-form-group--error" if
-    @pre_application.pa_project_enquiry.errors[:programme_outcomes].any? %>">
+  <div class="govuk-character-count" data-module="govuk-character-count" data-maxwords="200">
+    <div class="govuk-form-group <%= "govuk-form-group--error" if
+      @pre_application.pa_project_enquiry.errors[:programme_outcomes].any? %>">
 
-    <h1 class="govuk-label-wrapper">
+      <h1 class="govuk-label-wrapper">
 
-      <%= 
-        f.label :programme_outcomes,
-        t('pa_project_enquiry.programme_outcomes.page_heading'),
-        class: "govuk-label govuk-label--xl govuk-!-margin-bottom-4"
-      %>
+        <%= 
+          f.label :programme_outcomes,
+          t('pa_project_enquiry.programme_outcomes.page_heading'),
+          class: "govuk-label govuk-label--xl govuk-!-margin-bottom-4"
+        %>
 
-    </h1>
+      </h1>
 
-    <span id="programme_outcomes-hint" class="govuk-hint">
+      <span id="programme_outcomes-hint" class="govuk-hint">
+        <%=
+          t(
+            'pa_project_enquiry.programme_outcomes.page_hint_html',
+            href:
+              link_to(
+                t('pa_project_enquiry.programme_outcomes.page_hint_href'),
+                "#{I18n.locale == :cy ? 'https://www.heritagefund.org.uk/cy/node/110862' : 'https://www.heritagefund.org.uk/funding/outcomes'}", 
+              )
+          )
+        %>
+      </span>
+
       <%=
-        t(
-          'pa_project_enquiry.programme_outcomes.page_hint_html',
-          href:
-            link_to(
-              t('pa_project_enquiry.programme_outcomes.page_hint_href'),
-              "#{I18n.locale == :cy ? 'https://www.heritagefund.org.uk/cy/node/110862' : 'https://www.heritagefund.org.uk/funding/outcomes'}", 
-            )
-        )
+        render partial: "partials/form_input_errors",
+                locals: {form_object: @pre_application.pa_project_enquiry,
+                          input_field_id: :programme_outcomes} if 
+                            @pre_application.pa_project_enquiry.errors[:programme_outcomes].any?
       %>
-    </span>
 
-    <%=
-      render partial: "partials/form_input_errors",
-               locals: {form_object: @pre_application.pa_project_enquiry,
-                        input_field_id: :programme_outcomes} if 
-                          @pre_application.pa_project_enquiry.errors[:programme_outcomes].any?
-    %>
+      <%=
+        f.text_area :programme_outcomes,
+                    rows: 10,
+                    id: "pa_project_enquiry_programme_outcomes",
+                    class: "govuk-textarea  #{'govuk-js-character-count' if I18n.locale == :"en-GB"} " \
+                            "#{' govuk-textarea--error' if
+                        @pre_application.pa_project_enquiry.errors[:programme_outcomes].any?}",
+                    "aria-describedby" => "programme_outcomes-hint pa_project_enquiry_programme_outcomes-info" 
+      %>
 
-    <%=
-      f.text_area :programme_outcomes,
-                  rows: 10,
-                  id: "pa_project_enquiry_programme_outcomes",
-                  class: "govuk-textarea  #{'govuk-js-character-count' if I18n.locale == :"en-GB"} " \
-                          "#{' govuk-textarea--error' if
-                      @pre_application.pa_project_enquiry.errors[:programme_outcomes].any?}",
-                  "aria-describedby" => "programme_outcomes-hint pa_project_enquiry_programme_outcomes-info" 
-    %>
+      <span id="pa_project_enquiry_programme_outcomes-info"
+            class="govuk-hint govuk-character-count__message"
+            aria-live="polite">
+        <%= t('generic.word_count', max_words: 200) %>
+      </span>
 
-    <span id="pa_project_enquiry_programme_outcomes-info"
-          class="govuk-hint govuk-character-count__message"
-          aria-live="polite">
-      <%= t('generic.word_count', max_words: 200) %>
-    </span>
-
+    </div>
   </div>
-</div>
 
-  <%= 
-    render(
-      ButtonComponent.new(
-        element: "button"
-      )
-    ) 
-  %>
-
+  <%= render(ButtonComponent.new(element: "button")) %>
 <% end %>

--- a/app/views/pre_application/project_enquiry/project_participants/show.html.erb
+++ b/app/views/pre_application/project_enquiry/project_participants/show.html.erb
@@ -25,57 +25,50 @@
   method: :put do |f| 
 %>
 
-<div class="govuk-character-count" data-module="govuk-character-count"
-      data-maxwords="100">
-  <div class="govuk-form-group <%= "govuk-form-group--error" if
-    @pre_application.pa_project_enquiry.errors[:project_participants].any? %>">
+  <div class="govuk-character-count" data-module="govuk-character-count" data-maxwords="100">
+    <div class="govuk-form-group <%= "govuk-form-group--error" if
+      @pre_application.pa_project_enquiry.errors[:project_participants].any? %>">
 
-    <h1 class="govuk-label-wrapper">
+      <h1 class="govuk-label-wrapper">
 
-      <%= 
-        f.label :project_participants,
-        t('pa_project_enquiry.project_participants.page_heading'),
-        class: "govuk-label govuk-label--xl govuk-!-margin-bottom-4"
+        <%= 
+          f.label :project_participants,
+          t('pa_project_enquiry.project_participants.page_heading'),
+          class: "govuk-label govuk-label--xl govuk-!-margin-bottom-4"
+        %>
+
+      </h1>
+
+      <span id="project_participants-hint" class="govuk-hint">
+        <%= t('pa_project_enquiry.project_participants.page_hint') %>
+      </span>
+
+
+      <%=
+        render partial: "partials/form_input_errors",
+                locals: {form_object: @pre_application.pa_project_enquiry,
+                          input_field_id: :project_participants} if 
+                            @pre_application.pa_project_enquiry.errors[:project_participants].any?
       %>
 
-    </h1>
+      <%=
+        f.text_area :project_participants,
+                    rows: 10,
+                    id: "pa_project_enquiry_project_participants",
+                    class: "govuk-textarea  #{'govuk-js-character-count' if I18n.locale == :"en-GB"} " \
+                            "#{' govuk-textarea--error' if
+                        @pre_application.pa_project_enquiry.errors[:project_participants].any?}",
+                    "aria-describedby" => "project_participants-hint pa_project_enquiry_project_participants-info" 
+      %>
 
-    <span id="project_participants-hint" class="govuk-hint">
-      <%= t('pa_project_enquiry.project_participants.page_hint') %>
-    </span>
+      <span id="pa_project_enquiry_project_participants-info" 
+            class="govuk-hint govuk-character-count__message"
+            aria-live="polite">
+        <%= t('generic.word_count', max_words: 100) %>
+      </span>
 
-
-    <%=
-      render partial: "partials/form_input_errors",
-               locals: {form_object: @pre_application.pa_project_enquiry,
-                        input_field_id: :project_participants} if 
-                          @pre_application.pa_project_enquiry.errors[:project_participants].any?
-    %>
-
-    <%=
-      f.text_area :project_participants,
-                  rows: 10,
-                  id: "pa_project_enquiry_project_participants",
-                  class: "govuk-textarea  #{'govuk-js-character-count' if I18n.locale == :"en-GB"} " \
-                          "#{' govuk-textarea--error' if
-                      @pre_application.pa_project_enquiry.errors[:project_participants].any?}",
-                  "aria-describedby" => "project_participants-hint pa_project_enquiry_project_participants-info" 
-    %>
-
-    <span id="pa_project_enquiry_project_participants-info" 
-          class="govuk-hint govuk-character-count__message"
-          aria-live="polite">
-      <%= t('generic.word_count', max_words: 100) %>
-    </span>
-
+    </div>
   </div>
 
-  <%= 
-    render(
-      ButtonComponent.new(
-        element: "button"
-      )
-    ) 
-  %>
-
+  <%= render(ButtonComponent.new(element: "button")) %>
 <% end %>


### PR DESCRIPTION
## Proposed changes

A fix for the alignment issue of the Related Links section on the PEF Who will be involved page.
The section has been right aligned to match all the other pages.

[Trello Card here](https://trello.com/c/6e5CEAQJ)

## Screenshot (if applicable)
Before:

![image](https://github.com/heritagefund/funding-frontend/assets/13278991/b633ab98-c869-498a-81eb-29f3bd8721c3)

After:

![image](https://github.com/heritagefund/funding-frontend/assets/13278991/a50ea79b-8c15-47ac-897a-42638f85e926)
